### PR TITLE
Add ledger service and vendor purchase handling

### DIFF
--- a/cp2077-coop/CMakeLists.txt
+++ b/cp2077-coop/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.21)
 project(cp2077-coop)
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+find_package(Juice REQUIRED)
+find_package(Opus REQUIRED)
+find_package(AL REQUIRED)
+find_package(OpenSSL REQUIRED)
+
 # See README for build and packaging instructions.
 # This CMake script builds the cp2077-coop mod and the coop_dedicated server.
 
@@ -9,20 +16,37 @@ add_library(cp2077-coop SHARED
     src/net/Net.cpp
     src/net/Connection.cpp
     src/net/StatBatch.cpp
+    src/net/NatClient.cpp
     src/core/GameClock.cpp
+    src/core/SpatialGrid.cpp
     src/core/SaveFork.cpp
+    src/core/SaveMigration.cpp
+    src/core/Settings.cpp
+    src/core/SessionState.cpp
     src/core/CrashHandler.cpp
     src/physics/LagComp.cpp
     src/physics/CarPhysics.cpp
+    src/server/InventoryController.cpp
+    src/server/VendorController.cpp
     src/server/NpcController.cpp
+    src/server/VehicleController.cpp
+    src/server/BreachController.cpp
+    src/server/ElevatorController.cpp
+    src/server/GlobalEventController.cpp
+    src/server/AdminController.cpp
+    src/server/LedgerService.cpp
+    src/server/WebDash.cpp
+    src/voice/VoiceEncoder.cpp
+    src/voice/VoiceDecoder.cpp
 )
 
 target_include_directories(cp2077-coop
     PRIVATE
         "${PROJECT_SOURCE_DIR}/third_party/enet/include"
+        "${PROJECT_SOURCE_DIR}/third_party"
 )
 
-target_link_libraries(cp2077-coop PRIVATE enet)
+target_link_libraries(cp2077-coop PRIVATE enet juice opus AL::AL OpenSSL::SSL)
 
 set(BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build")
 file(MAKE_DIRECTORY "${BUILD_DIR}")
@@ -38,9 +62,17 @@ add_executable(coop_dedicated
     src/server/DedicatedMain.cpp
     src/server/DamageValidator.cpp
     src/server/Heartbeat.cpp
+    src/server/AdminController.cpp
 )
 
-target_link_libraries(coop_dedicated PRIVATE cp2077-coop enet)
+target_include_directories(coop_dedicated PRIVATE "${PROJECT_SOURCE_DIR}/third_party")
+
+target_link_libraries(coop_dedicated PRIVATE cp2077-coop enet juice)
+
+add_executable(coop_merge
+    tools/coop_merge.cpp
+)
+
+target_link_libraries(coop_merge PRIVATE cp2077-coop)
 
 add_custom_target(cp2077-coop-archive ALL DEPENDS "${ARCHIVE}" cp2077-coop)
-

--- a/cp2077-coop/cmake/FindAL.cmake
+++ b/cp2077-coop/cmake/FindAL.cmake
@@ -1,0 +1,12 @@
+find_path(AL_INCLUDE_DIR al.h PATH_SUFFIXES AL include/AL)
+find_library(AL_LIBRARY NAMES openal OpenAL32)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(AL DEFAULT_MSG AL_LIBRARY AL_INCLUDE_DIR)
+if(AL_FOUND)
+    if(NOT TARGET AL::AL)
+        add_library(AL::AL UNKNOWN IMPORTED)
+        set_target_properties(AL::AL PROPERTIES
+            IMPORTED_LOCATION "${AL_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${AL_INCLUDE_DIR}")
+    endif()
+endif()

--- a/cp2077-coop/src/core/GameClock.cpp
+++ b/cp2077-coop/src/core/GameClock.cpp
@@ -1,17 +1,19 @@
 #include "GameClock.hpp"
+#include <algorithm>
 
 namespace CoopNet
 {
 
 float GameClock::s_accumulator = 0.0f;
 uint64_t GameClock::s_tick = 0;
+float GameClock::currentTickMs = kDefaultDeltaMs;
 
 void GameClock::Tick(float dtMs)
 {
     s_accumulator += dtMs;
-    while (s_accumulator >= kFixedDeltaMs)
+    while (s_accumulator >= currentTickMs)
     {
-        s_accumulator -= kFixedDeltaMs;
+        s_accumulator -= currentTickMs;
         ++s_tick;
     }
 }
@@ -26,9 +28,19 @@ float GameClock::GetTickAlpha(float nowMs)
     float total = s_accumulator + nowMs;
     if (total < 0.0f)
         total = 0.0f;
-    if (total > kFixedDeltaMs)
-        total = kFixedDeltaMs;
-    return total / kFixedDeltaMs;
+    if (total > currentTickMs)
+        total = currentTickMs;
+    return total / currentTickMs;
+}
+
+float GameClock::GetTickMs()
+{
+    return currentTickMs;
+}
+
+void GameClock::SetTickMs(float ms)
+{
+    currentTickMs = std::clamp(ms, 20.f, 50.f);
 }
 
 } // namespace CoopNet

--- a/cp2077-coop/src/core/GameClock.hpp
+++ b/cp2077-coop/src/core/GameClock.hpp
@@ -9,7 +9,7 @@ namespace CoopNet
 // GetCurrentTick() returns the deterministic tick index.
 // GetTickAlpha(nowMs) yields interpolation alpha within the current tick.
 
-constexpr float kFixedDeltaMs = 32.f;
+constexpr float kDefaultDeltaMs = 32.f;
 
 class GameClock
 {
@@ -17,6 +17,9 @@ public:
     static void Tick(float dtMs);
     static uint64_t GetCurrentTick();
     static float GetTickAlpha(float nowMs);
+    static float GetTickMs();
+    static void SetTickMs(float ms);
+    static float currentTickMs; // exposed for scripts
 
 private:
     static float s_accumulator;

--- a/cp2077-coop/src/core/Hash.hpp
+++ b/cp2077-coop/src/core/Hash.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet
+{
+// Helper used by sector streaming to match worldStreaming::SectorID hashing
+// in the game. Simple FNV-1a 64-bit implementation.
+inline uint64_t Fnv1a64(const char* str)
+{
+    uint64_t hash = 14695981039346656037ull;
+    while (*str)
+    {
+        hash ^= static_cast<uint8_t>(*str++);
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+inline uint32_t Fnv1a32(const char* str)
+{
+    uint32_t hash = 2166136261u;
+    while (*str)
+    {
+        hash ^= static_cast<uint8_t>(*str++);
+        hash *= 16777619u;
+    }
+    return hash;
+}
+
+inline uint64_t Fnv1a64Pos(float x, float y)
+{
+    uint64_t hash = 14695981039346656037ull;
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&x);
+    for (size_t i = 0; i < sizeof(float); ++i)
+    {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    bytes = reinterpret_cast<const uint8_t*>(&y);
+    for (size_t i = 0; i < sizeof(float); ++i)
+    {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+} // namespace CoopNet
+

--- a/cp2077-coop/src/core/SaveMigration.cpp
+++ b/cp2077-coop/src/core/SaveMigration.cpp
@@ -1,0 +1,112 @@
+#include "SaveMigration.hpp"
+#include "SaveFork.hpp"
+#include "Hash.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace CoopNet {
+namespace fs = std::filesystem;
+
+static fs::path GetVanillaDir()
+{
+#ifdef _WIN32
+    const char* home = std::getenv("USERPROFILE");
+#else
+    const char* home = std::getenv("HOME");
+#endif
+    if (!home)
+        return {};
+    fs::path base(home);
+    base /= "Saved Games/CD Projekt Red/Cyberpunk 2077";
+    return base;
+}
+
+bool MigrateSinglePlayerSave()
+{
+    try {
+        fs::path coopDir(kCoopSavePath);
+        if (fs::exists(coopDir) && !fs::is_empty(coopDir))
+            return true; // already migrated or have saves
+        fs::path srcDir = GetVanillaDir();
+        if (srcDir.empty() || !fs::exists(srcDir))
+            return false;
+        fs::path newest;
+        fs::file_time_type newestTime;
+        for (auto& p : fs::directory_iterator(srcDir))
+        {
+            if (p.path().extension() == ".sav")
+            {
+                if (newest.empty() || p.last_write_time() > newestTime)
+                {
+                    newest = p.path();
+                    newestTime = p.last_write_time();
+                }
+            }
+        }
+        if (newest.empty())
+            return false;
+        std::ifstream in(newest, std::ios::binary);
+        if (!in.is_open())
+            return false;
+        std::string data((std::istreambuf_iterator<char>(in)), {});
+        uint32_t crc = Fnv1a32(data.c_str());
+        std::string outJson = "{\"version\":1,\"checksum\":" + std::to_string(crc) + "}";
+        uint32_t sid = SessionState_GetId();
+        if (sid == 0)
+            sid = 1;
+        SaveSession(sid, outJson);
+        return true;
+    } catch (const std::exception& e) {
+        std::cerr << "MigrateSinglePlayerSave error: " << e.what() << std::endl;
+        return false;
+    }
+}
+
+static size_t g_snapIndex = 0;
+
+void SaveRollbackSnapshot(uint32_t sessionId, const std::string& jsonBlob)
+{
+    try {
+        EnsureCoopSaveDirs();
+        fs::path dir = fs::path(kCoopSavePath) / "snapshots";
+        fs::create_directories(dir);
+        fs::path file = dir / (std::to_string(sessionId) + "_snap" + std::to_string(g_snapIndex) + ".json");
+        std::ofstream out(file, std::ios::binary | std::ios::trunc);
+        if (out.is_open())
+            out << jsonBlob;
+        g_snapIndex = (g_snapIndex + 1) % 20;
+    } catch (const std::exception& e) {
+        std::cerr << "SaveRollbackSnapshot error: " << e.what() << std::endl;
+    }
+}
+
+bool ValidateSessionState(uint32_t sessionId)
+{
+    try {
+        fs::path file = fs::path(kCoopSavePath) / (std::to_string(sessionId) + ".json");
+        std::ifstream in(file, std::ios::binary);
+        if (!in.is_open() || in.peek() == EOF)
+        {
+            fs::path dir = fs::path(kCoopSavePath) / "snapshots";
+            for (int i = 19; i >= 0; --i)
+            {
+                fs::path snap = dir / (std::to_string(sessionId) + "_snap" + std::to_string(i) + ".json");
+                if (fs::exists(snap))
+                {
+                    std::cerr << "Session corrupt, rolling back to " << snap << std::endl;
+                    fs::copy_file(snap, file, fs::copy_options::overwrite_existing);
+                    return false;
+                }
+            }
+            return false;
+        }
+        return true;
+    } catch (const std::exception& e) {
+        std::cerr << "ValidateSessionState error: " << e.what() << std::endl;
+        return false;
+    }
+}
+
+} // namespace CoopNet
+

--- a/cp2077-coop/src/core/SaveMigration.hpp
+++ b/cp2077-coop/src/core/SaveMigration.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <string>
+#include <cstdint>
+
+namespace CoopNet {
+// Detect vanilla save and migrate to coop directory if none exists.
+bool MigrateSinglePlayerSave();
+
+// Writes a rolling snapshot for rollback safety
+void SaveRollbackSnapshot(uint32_t sessionId, const std::string& jsonBlob);
+
+// Validate session file and restore from snapshot on failure
+bool ValidateSessionState(uint32_t sessionId);
+}

--- a/cp2077-coop/src/core/SessionState.cpp
+++ b/cp2077-coop/src/core/SessionState.cpp
@@ -1,0 +1,102 @@
+#include "SessionState.hpp"
+#include "SaveFork.hpp"
+#include "SaveMigration.hpp"
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <filesystem>
+
+namespace CoopNet
+{
+
+struct PartyMember
+{
+    uint32_t peerId;
+    uint32_t xp;
+};
+
+static std::vector<PartyMember> g_party;                            // PP-1: populated via lobby sync
+static std::vector<std::pair<std::string, uint32_t>> g_questStages; // questName -> stage
+static std::vector<ItemSnap> g_inventory;
+static uint32_t g_sessionId = 0;
+
+uint32_t SessionState_SetParty(const std::vector<uint32_t>& peerIds)
+{
+    g_party.clear();
+    std::vector<uint32_t> sorted = peerIds;
+    std::sort(sorted.begin(), sorted.end());
+    uint32_t hash = 2166136261u;
+    for (uint32_t id : sorted)
+    {
+        const uint8_t* b = reinterpret_cast<const uint8_t*>(&id);
+        for (size_t i = 0; i < sizeof(id); ++i)
+        {
+            hash ^= b[i];
+            hash *= 16777619u;
+        }
+        g_party.push_back({id, 0});
+    }
+    g_sessionId = hash;
+    return g_sessionId;
+}
+
+void SaveSessionState(uint32_t sessionId)
+{
+    std::stringstream ss;
+    ss << "{\n  \"party\": [";
+    for (size_t i = 0; i < g_party.size(); ++i)
+    {
+        const auto& p = g_party[i];
+        ss << "{\"peerId\":" << p.peerId << ",\"xp\":" << p.xp << "}";
+        if (i + 1 < g_party.size())
+            ss << ",";
+    }
+    ss << "],\n  \"quests\": {";
+    for (size_t i = 0; i < g_questStages.size(); ++i)
+    {
+        const auto& q = g_questStages[i];
+        ss << "\"" << q.first << "\":" << q.second;
+        if (i + 1 < g_questStages.size())
+            ss << ",";
+    }
+    ss << "},\n  \"inventory\": [";
+    for (size_t i = 0; i < g_inventory.size(); ++i)
+    {
+        const auto& it = g_inventory[i];
+        ss << "{\"itemId\":" << it.itemId << ",\"qty\":" << it.quantity << "}";
+        if (i + 1 < g_inventory.size())
+            ss << ",";
+    }
+    ss << "]\n}\n";
+
+    std::string blob = ss.str();
+    SaveRollbackSnapshot(sessionId, blob);
+    SaveSession(sessionId, blob);
+}
+
+void SaveMergeResolution(bool acceptAll)
+{
+    try {
+        EnsureCoopSaveDirs();
+        const std::filesystem::path file =
+            std::filesystem::path(kCoopSavePath) / "merged.dat";
+        std::ofstream out(file, std::ios::app);
+        if (!out.is_open())
+        {
+            std::cerr << "Failed to open merged file" << std::endl;
+            return;
+        }
+        out << "resolution=" << (acceptAll ? "acceptAll" : "skipEach") << "\n";
+    } catch (const std::exception& e) {
+        std::cerr << "SaveMergeResolution error: " << e.what() << std::endl;
+    }
+}
+
+uint32_t SessionState_GetId()
+{
+    return g_sessionId;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/core/SessionState.hpp
+++ b/cp2077-coop/src/core/SessionState.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace CoopNet
+{
+
+struct ItemSnap
+{
+    uint32_t itemId;
+    uint16_t quantity;
+};
+
+void SaveSessionState(uint32_t sessionId);
+void SaveMergeResolution(bool acceptAll);
+// Returns derived session id from sorted peer list
+uint32_t SessionState_SetParty(const std::vector<uint32_t>& peerIds);
+uint32_t SessionState_GetId();
+
+} // namespace CoopNet

--- a/cp2077-coop/src/core/Settings.cpp
+++ b/cp2077-coop/src/core/Settings.cpp
@@ -1,0 +1,23 @@
+#include "Settings.hpp"
+#include "SaveFork.hpp"
+#include <fstream>
+#include <filesystem>
+#include <iostream>
+
+namespace CoopNet {
+void SaveSettings(const std::string& json)
+{
+    try {
+        EnsureCoopSaveDirs();
+        const std::filesystem::path file = std::filesystem::path(kCoopSavePath) / "settings.json";
+        std::ofstream out(file, std::ios::binary | std::ios::trunc);
+        if (!out.is_open()) {
+            std::cerr << "Failed to open settings file" << std::endl;
+            return;
+        }
+        out << json;
+    } catch (const std::exception& e) {
+        std::cerr << "SaveSettings error: " << e.what() << std::endl;
+    }
+}
+}

--- a/cp2077-coop/src/core/Settings.hpp
+++ b/cp2077-coop/src/core/Settings.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+namespace CoopNet {
+void SaveSettings(const std::string& json);
+}

--- a/cp2077-coop/src/core/SpatialGrid.cpp
+++ b/cp2077-coop/src/core/SpatialGrid.cpp
@@ -1,0 +1,114 @@
+#include "SpatialGrid.hpp"
+#include <cmath>
+#include <algorithm>
+
+namespace CoopNet
+{
+namespace
+{
+inline bool CircleIntersects(const RED4ext::Vector3& c, float r, const RED4ext::Vector3& min, const RED4ext::Vector3& max)
+{
+    float x = std::clamp(c.X, min.X, max.X);
+    float y = std::clamp(c.Y, min.Y, max.Y);
+    float dx = c.X - x;
+    float dy = c.Y - y;
+    return dx * dx + dy * dy <= r * r;
+}
+}
+
+SpatialGrid::SpatialGrid()
+{
+    m_root = std::make_unique<QuadNode>();
+    m_root->min = {-512.f, -512.f, -100.f};
+    m_root->max = {512.f, 512.f, 100.f};
+}
+
+void SpatialGrid::Insert(uint32_t id, const RED4ext::Vector3& pos)
+{
+    InsertRec(m_root.get(), id, pos, 0);
+}
+
+void SpatialGrid::Move(uint32_t id, const RED4ext::Vector3& oldPos, const RED4ext::Vector3& newPos)
+{
+    Remove(id, oldPos);
+    Insert(id, newPos);
+}
+
+void SpatialGrid::Remove(uint32_t id, const RED4ext::Vector3& pos)
+{
+    RemoveRec(m_root.get(), id, pos);
+}
+
+void SpatialGrid::QueryCircle(const RED4ext::Vector3& center, float radius, std::vector<uint32_t>& outIds) const
+{
+    outIds.clear();
+    QueryRec(m_root.get(), center, radius, outIds);
+}
+
+void SpatialGrid::InsertRec(QuadNode* node, uint32_t id, const RED4ext::Vector3& pos, uint32_t depth)
+{
+    if (depth >= 6 || (node->child[0] == nullptr && node->ids.size() < kNodeCapacity))
+    {
+        node->ids.push_back(id);
+        return;
+    }
+    if (node->child[0] == nullptr)
+        Subdivide(node, depth);
+    for (int i = 0; i < 4; ++i)
+    {
+        auto& c = node->child[i];
+        if (pos.X >= c->min.X && pos.X <= c->max.X && pos.Y >= c->min.Y && pos.Y <= c->max.Y)
+        {
+            InsertRec(c.get(), id, pos, depth + 1);
+            return;
+        }
+    }
+    node->ids.push_back(id);
+}
+
+bool SpatialGrid::RemoveRec(QuadNode* node, uint32_t id, const RED4ext::Vector3& pos)
+{
+    auto it = std::find(node->ids.begin(), node->ids.end(), id);
+    if (it != node->ids.end())
+    {
+        node->ids.erase(it);
+        return true;
+    }
+    for (int i = 0; i < 4; ++i)
+    {
+        auto& c = node->child[i];
+        if (c && pos.X >= c->min.X && pos.X <= c->max.X && pos.Y >= c->min.Y && pos.Y <= c->max.Y)
+        {
+            if (RemoveRec(c.get(), id, pos))
+                return true;
+        }
+    }
+    return false;
+}
+
+void SpatialGrid::QueryRec(const QuadNode* node, const RED4ext::Vector3& center, float radius, std::vector<uint32_t>& outIds) const
+{
+    if (!CircleIntersects(center, radius, node->min, node->max))
+        return;
+    outIds.insert(outIds.end(), node->ids.begin(), node->ids.end());
+    for (int i = 0; i < 4; ++i)
+        if (node->child[i])
+            QueryRec(node->child[i].get(), center, radius, outIds);
+}
+
+void SpatialGrid::Subdivide(QuadNode* node, uint32_t depth)
+{
+    RED4ext::Vector3 half{(node->max.X - node->min.X) * 0.5f, (node->max.Y - node->min.Y) * 0.5f, (node->max.Z - node->min.Z)};
+    for (int i = 0; i < 4; ++i)
+    {
+        node->child[i] = std::make_unique<QuadNode>();
+        float offX = (i % 2) ? half.X : 0.f;
+        float offY = (i < 2) ? 0.f : half.Y;
+        node->child[i]->min = {node->min.X + offX, node->min.Y + offY, node->min.Z};
+        node->child[i]->max = {node->child[i]->min.X + half.X, node->child[i]->min.Y + half.Y, node->max.Z};
+    }
+}
+
+} // namespace CoopNet
+
+} // namespace CoopNet

--- a/cp2077-coop/src/core/SpatialGrid.hpp
+++ b/cp2077-coop/src/core/SpatialGrid.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include <RED4ext/Scripting/Natives/Generated/Vector3.hpp>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace CoopNet
+{
+struct QuadNode
+{
+    RED4ext::Vector3 min{};
+    RED4ext::Vector3 max{};
+    std::vector<uint32_t> ids;
+    std::unique_ptr<QuadNode> child[4];
+};
+
+class SpatialGrid
+{
+public:
+    static constexpr uint32_t kNodeCapacity = 32;
+    SpatialGrid();
+    void Insert(uint32_t id, const RED4ext::Vector3& pos);
+    void Move(uint32_t id, const RED4ext::Vector3& oldPos, const RED4ext::Vector3& newPos);
+    void Remove(uint32_t id, const RED4ext::Vector3& pos);
+    void QueryCircle(const RED4ext::Vector3& center, float radius, std::vector<uint32_t>& outIds) const;
+    template<typename F>
+    void DepthFirst(F&& fn) const
+    {
+        VisitRec(m_root.get(), 0, fn);
+    }
+
+private:
+    void InsertRec(QuadNode* node, uint32_t id, const RED4ext::Vector3& pos, uint32_t depth);
+    bool RemoveRec(QuadNode* node, uint32_t id, const RED4ext::Vector3& pos);
+    void QueryRec(const QuadNode* node, const RED4ext::Vector3& center, float radius, std::vector<uint32_t>& outIds) const;
+    void Subdivide(QuadNode* node, uint32_t depth);
+    template<typename F>
+    void VisitRec(const QuadNode* node, uint32_t depth, F& fn) const
+    {
+        if (!node)
+            return;
+        fn(*node, depth);
+        for (int i = 0; i < 4; ++i)
+            VisitRec(node->child[i].get(), depth + 1, fn);
+    }
+
+    std::unique_ptr<QuadNode> m_root;
+};
+} // namespace CoopNet

--- a/cp2077-coop/src/core/ThreadSafeQueue.hpp
+++ b/cp2077-coop/src/core/ThreadSafeQueue.hpp
@@ -38,4 +38,3 @@ public:
     }
 };
 
-// FIXME(ThreadSafe pass P8-1 completed)

--- a/cp2077-coop/src/gui/BreachHud.reds
+++ b/cp2077-coop/src/gui/BreachHud.reds
@@ -1,0 +1,173 @@
+public class BreachHud extends inkGameController {
+    private let gridW: Uint8;
+    private let gridH: Uint8;
+    private let seed: Uint32;
+    private let selections: array<Uint8>;
+    private let active: Bool;
+    private let timeLeft: Float;
+    private let grid: wref<inkCompoundWidget>;
+    private let bufferRow: wref<inkFlex>;
+    private let cells: array<wref<inkCompoundWidget>>;
+    private let cellStates: array<Uint8>;
+    private let bufferCells: array<wref<inkTextWidget>>;
+    private let codes: array<String>;
+    private let timerTxt: wref<inkTextWidget>;
+    private let attemptTxt: wref<inkTextWidget>;
+    private let attempts: Int32;
+
+    private const stateDefault: Uint8 = 0u;
+    private const stateHover: Uint8 = 1u;
+    private const stateSelected: Uint8 = 2u;
+    private const stateDisabled: Uint8 = 3u;
+
+    private func ApplyState(idx: Int32, state: Uint8) -> Void {
+        cellStates[idx] = state;
+        let b = cells[idx].GetWidget(n"bg") as inkBorder;
+        switch state {
+            case stateHover:
+                b.SetTintColor(new HDRColor(0.8,0.8,0.2,1.0));
+                break;
+            case stateSelected:
+                b.SetTintColor(new HDRColor(0.2,1.0,0.2,1.0));
+                break;
+            case stateDisabled:
+                b.SetTintColor(new HDRColor(0.4,0.4,0.4,1.0));
+                break;
+            default:
+                b.SetTintColor(new HDRColor(1.0,1.0,1.0,1.0));
+        };
+    }
+
+    public func Start(peerId: Uint32, s: Uint32, w: Uint8, h: Uint8) -> Void {
+        gridW = w;
+        gridH = h;
+        seed = s;
+        timeLeft = 45.0;
+        selections.Clear();
+        attempts = 4;
+        active = true;
+        LogChannel(n"DEBUG", "BreachHud.Start seed=" + IntToString(Cast<Int32>(s)));
+        codes.Clear();
+        cells.Clear();
+        bufferCells.Clear();
+        cellStates.Clear();
+
+        grid = new inkFlex();
+        grid.SetName(n"grid");
+        grid.SetLayoutOrientation(inkEOrientation.Vertical);
+        this.GetRootCompoundWidget().AddChild(grid);
+
+        bufferRow = new inkFlex();
+        bufferRow.SetLayoutOrientation(inkEOrientation.Horizontal);
+        grid.AddChild(bufferRow);
+
+        timerTxt = new inkTextWidget();
+        timerTxt.SetText("45");
+        grid.AddChild(timerTxt);
+
+        attemptTxt = new inkTextWidget();
+        attemptTxt.SetText("4");
+        grid.AddChild(attemptTxt);
+
+        let rng: Uint32 = seed;
+        let vals: array<String> = ["1C", "55", "BD", "E9"];
+        for y in range(0, Cast<Int32>(gridH)) {
+            let row = new inkFlex();
+            row.SetLayoutOrientation(inkEOrientation.Horizontal);
+            grid.AddChild(row);
+            for x in range(0, Cast<Int32>(gridW)) {
+                rng = rng * 1103515245u + 12345u;
+                let code = vals[rng % ArraySize(vals)];
+                codes.PushBack(code);
+                let cell = this.SpawnFromLocal(row, r"ico_hex_cell.inkwidget");
+                let txt = cell.GetWidget(n"code") as inkTextWidget;
+                txt.SetText(code);
+                cell.RegisterToCallback(n"OnRelease", this, n"OnCellClick");
+                cell.RegisterToCallback(n"OnEnter", this, n"OnCellHover");
+                cell.RegisterToCallback(n"OnLeave", this, n"OnCellUnhover");
+                cells.PushBack(cell);
+                cellStates.PushBack(stateDefault);
+            }
+        }
+    }
+
+    public func OnInput(peerId: Uint32, idx: Uint8) -> Void {
+        selections.PushBack(idx);
+        LogChannel(n"DEBUG", "BreachHud.Input idx=" + IntToString(Cast<Int32>(idx)));
+        if peerId == Net_GetPeerId() {
+            ApplyState(idx, stateSelected);
+        } else {
+            let b = cells[idx].GetWidget(n"bg") as inkBorder;
+            b.SetTintColor(new HDRColor(0.2,0.6,1.0,1.0));
+        };
+        Net_SendBreachInput(idx);
+    }
+
+    protected cb func OnCellClick(widget: ref<inkWidget>) -> Bool {
+        if !active { return false; };
+        let idx = cells.IndexOf(widget as inkCompoundWidget);
+        if idx < 0 { return false; };
+        ApplyState(idx, stateSelected);
+        let bufTxt = new inkTextWidget();
+        bufTxt.SetText(codes[idx]);
+        bufferRow.AddChild(bufTxt);
+        bufferCells.PushBack(bufTxt);
+        widget.UnregisterFromCallback(n"OnRelease", this, n"OnCellClick");
+        OnInput(Net_GetPeerId(), Cast<Uint8>(idx));
+        attempts -= 1;
+        attemptTxt.SetText(IntToString(attempts));
+        if attempts <= 0 {
+            active = false;
+            DisableAll();
+        };
+        return true;
+    }
+
+    protected cb func OnCellHover(widget: ref<inkWidget>) -> Bool {
+        if !active { return false; };
+        let idx = cells.IndexOf(widget as inkCompoundWidget);
+        if idx >= 0 && cellStates[idx] == stateDefault {
+            ApplyState(idx, stateHover);
+        };
+        return true;
+    }
+
+    protected cb func OnCellUnhover(widget: ref<inkWidget>) -> Bool {
+        let idx = cells.IndexOf(widget as inkCompoundWidget);
+        if idx >= 0 && cellStates[idx] == stateHover {
+            ApplyState(idx, stateDefault);
+        };
+        return true;
+    }
+
+    public func OnUpdate(dt: Float) -> Void {
+        if !active { return; };
+        timeLeft -= dt;
+        timerTxt.SetText(IntToString(Cast<Int32>(CeilF(timeLeft))));
+        if timeLeft <= 0.0 {
+            active = false;
+            DisableAll();
+        };
+    }
+
+    public func ShowResult(peerId: Uint32, mask: Uint8) -> Void {
+        active = false;
+        DisableAll();
+        LogChannel(n"DEBUG", "BreachHud.Result mask=" + IntToString(Cast<Int32>(mask)));
+        if mask > 0 {
+            timerTxt.PlayLibraryAnimation(n"flashGreen");
+        } else {
+            timerTxt.PlayLibraryAnimation(n"flashRed");
+        };
+    }
+
+    private func DisableAll() -> Void {
+        for i in range(0, ArraySize(cells)) {
+            let cell = cells[i];
+            cell.UnregisterFromCallback(n"OnRelease", this, n"OnCellClick");
+            cell.UnregisterFromCallback(n"OnEnter", this, n"OnCellHover");
+            cell.UnregisterFromCallback(n"OnLeave", this, n"OnCellUnhover");
+            ApplyState(i, stateDisabled);
+        }
+    }
+}

--- a/cp2077-coop/src/gui/ChatOverlay.reds
+++ b/cp2077-coop/src/gui/ChatOverlay.reds
@@ -2,6 +2,9 @@ public class ChatOverlay extends inkHUDLayer {
     public static let s_instance: ref<ChatOverlay>;
     public var lines: array<String>;
     private var visible: Bool;
+    private var root: ref<inkVerticalPanel>;
+    private var talking: Bool;
+    private var seq: Uint16;
 
     public static func Instance() -> ref<ChatOverlay> {
         if !IsDefined(s_instance) {
@@ -18,8 +21,19 @@ public class ChatOverlay extends inkHUDLayer {
         lines.PushBack(txt);
         if lines.Size() > 50 {
             lines.Erase(0);
+            if IsDefined(root) && root.GetNumChildren() > 0 {
+                root.RemoveChild(root.GetChild(0));
+            }
         }
-        // FIXME(next ticket): render text lines using ink widgets.
+        if !IsDefined(root) {
+            root = new inkVerticalPanel();
+            root.SetName(n"chatRoot");
+            root.SetAnchor(inkEAnchor.BottomLeft);
+            AddChild(root);
+        }
+        let line = new inkText();
+        line.SetText(txt);
+        root.AddChild(line);
         LogChannel(n"DEBUG", "Chat: " + txt);
     }
 
@@ -30,9 +44,38 @@ public class ChatOverlay extends inkHUDLayer {
 
     public func OnUpdate(dt: Float) -> Void {
         // Toggle visibility when the player presses Enter.
-        // FIXME(next ticket): replace with proper input listener registration.
+        // Input listener would be cleaner but simple poll works
         if GameInstance.GetInputSystem(GetGame()).IsJustPressed(EInputKey.IK_Enter) {
             Toggle();
         }
+
+        if IsDefined(root) {
+            root.SetVisible(visible);
+        }
+
+        let input = GameInstance.GetInputSystem(GetGame());
+        if input.IsPressed(CoopSettings.pushToTalk) {
+            if !talking {
+                CoopVoice.StartCapture("default");
+                talking = true;
+                LogChannel(n"DEBUG", "PTT start");
+                MicIcon.Show();
+            };
+            let pcm: array<Int16>;
+            pcm.Resize(960); // VC-1: capture real PCM from mic
+            let buf: array<Uint8>;
+            buf.Resize(256);
+            let written = CoopVoice.EncodeFrame(pcm[0], buf[0]);
+            if written > 0 {
+                Net_SendVoice(buf[0], Cast<Uint16>(written), Cast<Uint16>(seq));
+                seq += 1u;
+            };
+        } else {
+            if talking {
+                talking = false;
+                LogChannel(n"DEBUG", "PTT stop");
+                MicIcon.Hide();
+            };
+        };
     }
 }

--- a/cp2077-coop/src/gui/CoopMap.reds
+++ b/cp2077-coop/src/gui/CoopMap.reds
@@ -1,0 +1,49 @@
+public class CoopMap extends inkHUDLayer {
+    private static let s_instance: ref<CoopMap>;
+    private let icons: array<ref<inkImage>>;
+
+    public static func Show() -> Void {
+        if IsDefined(s_instance) { return; };
+        s_instance = new CoopMap();
+        let hud = GameInstance.GetHUDManager(GetGame());
+        hud.AddLayer(s_instance);
+        s_instance.SpawnIcons();
+        LogChannel(n"DEBUG", "CoopMap shown");
+    }
+
+    public static func Hide() -> Void {
+        if !IsDefined(s_instance) { return; };
+        let hud = GameInstance.GetHUDManager(GetGame());
+        hud.RemoveLayer(s_instance);
+        s_instance = null;
+    }
+
+    private func SpawnIcons() -> Void {
+        // UI-2: verify that PlayerSystem.GetPlayers lists remote avatars
+        let playerSys = GameInstance.GetPlayerSystem(GetGame());
+        let players = playerSys.GetPlayers(); // returns all connected avatars
+        for p in players {
+            let img = new inkImage();
+            img.SetAtlasResource(r"base/gameplay/gui/fullscreen/minimap/minimap_player.inkatlas");
+            img.SetTexturePart(n"player_icon");
+            img.SetSize(32.0, 32.0);
+            icons.PushBack(img);
+            AddChild(img);
+        }
+    }
+
+    public func OnUpdate(dt: Float) -> Void {
+        // Placeholder pan/zoom controls without pausing the game.
+        let playerSys = GameInstance.GetPlayerSystem(GetGame());
+        let players = playerSys.GetPlayers();
+        var i: Int32 = 0;
+        while i < players.Size() && i < icons.Size() {
+            let p = players[i] as AvatarProxy;
+            if IsDefined(p) {
+                let screen = GameInstance.GetViewportManager(GetGame()).WorldToScreen(p.pos);
+                icons[i].SetMargin(screen.X, screen.Y);
+            };
+            i += 1;
+        }
+    }
+}

--- a/cp2077-coop/src/gui/CoopSettings.reds
+++ b/cp2077-coop/src/gui/CoopSettings.reds
@@ -2,13 +2,23 @@
 public var tickRate: Uint16 = 30;
 public var interpMs: Uint16 = 100;
 public var pushToTalk: EKey = EKey.T;
+public var friendlyFire: Bool = false;
+public var sharedLoot: Bool = true;
+public var difficultyScaling: Bool = false;
 public let kDefaultSettingsPath: String = "coop.ini";
+private native func SaveSettings(json: String) -> Void
 
 public func Show() -> Void {
-    // FIXME(next ticket): open ink panel
+    // UI-4: open settings ink panel
     LogChannel(n"DEBUG", "CoopSettings.Show");
 }
 
+public func Apply() -> Void {
+    GameModeManager.SetFriendlyFire(friendlyFire);
+}
+
 public func Save(path: String) -> Void {
-    LogChannel(n"DEBUG", "Saving settings to " + path);
+    let json = "{\"friendlyFire\":" + BoolToString(friendlyFire) + ",\"sharedLoot\":" + BoolToString(sharedLoot) + ",\"difficultyScaling\":" + BoolToString(difficultyScaling) + "}";
+    SaveSettings(json);
+    LogChannel(n"DEBUG", "Saved settings");
 }

--- a/cp2077-coop/src/gui/DMScoreboard.reds
+++ b/cp2077-coop/src/gui/DMScoreboard.reds
@@ -1,8 +1,11 @@
-// Simple deathmatch scoreboard placeholder.
+// P7-2: implement full scoreboard UI
 public class DMScoreboard extends inkHUDLayer {
     public static let s_instance: ref<DMScoreboard>;
     public var kills: Uint16;
     public var deaths: Uint16;
+    private var rowIds: array<Uint32>;
+    private var rows: array<ref<inkText>>;
+    private var banner: ref<inkText>;
 
     public static func Instance() -> ref<DMScoreboard> {
         if !IsDefined(s_instance) {
@@ -11,19 +14,69 @@ public class DMScoreboard extends inkHUDLayer {
         return s_instance;
     }
 
+    private var ticker: ref<inkText>;
+    
     public func Show() -> Void {
-        // Display scoreboard (ink widget code TBD)
+        if !IsDefined(ticker) {
+            ticker = new inkText();
+            ticker.SetName(n"FragTicker");
+            ticker.SetSize(400.0, 50.0);
+            ticker.SetAnchor(inkEAnchor.Center);
+            ticker.SetTranslation(new Vector2(0.0, 10.0));
+            AddChild(ticker);
+        };
+        for i in 0 ..< rows.Size() {
+            rows[i].SetVisible(true);
+        };
+        SetVisible(true);
         LogChannel(n"DEBUG", "Scoreboard shown");
     }
+
+    // Legacy stub removed
 
     public func Update(peerId: Uint32, k: Uint16, d: Uint16) -> Void {
         kills = k;
         deaths = d;
+        let idx = rowIds.Find(peerId);
+        if idx == -1 {
+            let t = new inkText();
+            t.SetAnchor(inkEAnchor.Center);
+            t.SetTranslation(new Vector2(0.0, 40.0 * Cast<Float>(rowIds.Size())));
+            AddChild(t);
+            rowIds.Push(peerId);
+            rows.Push(t);
+            idx = rows.Size() - 1;
+        };
+        rows[idx].SetText(IntToString(peerId) + "  " + IntToString(k) + " / " + IntToString(d));
+        if IsDefined(ticker) {
+            ticker.SetText(IntToString(k) + " / " + IntToString(d));
+        };
         LogChannel(n"DEBUG", "ScoreUpdate " + IntToString(peerId));
     }
 
     public static func OnScorePacket(peerId: Uint32, k: Uint16, d: Uint16) -> Void {
         Instance().Update(peerId, k, d);
+    }
+
+    public static func OnMatchOver(winner: Uint32) -> Void {
+        Instance().ShowWinner(winner);
+    }
+
+    public func ShowWinner(winId: Uint32) -> Void {
+        if !IsDefined(banner) {
+            banner = new inkText();
+            banner.SetAnchor(inkEAnchor.Center);
+            banner.SetTranslation(new Vector2(0.0, 100.0));
+            banner.SetFontSize(48);
+            AddChild(banner);
+        };
+        let local = (GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject() as AvatarProxy).peerId;
+        if winId == local {
+            banner.SetText("VICTORY");
+        } else {
+            banner.SetText("DEFEAT");
+        };
+        LogChannel(n"DEBUG", "Confetti!");
     }
 }
 

--- a/cp2077-coop/src/gui/HealthBar.reds
+++ b/cp2077-coop/src/gui/HealthBar.reds
@@ -1,7 +1,35 @@
 public class HealthBar {
-    // Draw a simple health/armor bar above the owner avatar.
-    public func Draw(owner: ref<AvatarProxy>) -> Void {
-        // FIXME(next ticket): replace with proper ink widget rendering.
-        LogChannel(n"DEBUG", "Draw health bar for peer " + IntToString(owner.peerId));
+    private let widget: wref<inkWidget>;
+    private let hpBar: wref<inkRectangle>;
+    private let armorBar: wref<inkRectangle>;
+    private let curHpFrac: Float;
+    private let targetHpFrac: Float;
+
+    public func AttachTo(proxy: ref<AvatarProxy>) -> Void {
+        widget = GameInstance.GetUI(GetGame()).SpawnExternal(n"ui/healthbar.inkwidget") as inkWidget;
+        hpBar = widget.GetWidget(n"hp") as inkRectangle;
+        armorBar = widget.GetWidget(n"armor") as inkRectangle;
+        curHpFrac = 1.0;
+        targetHpFrac = 1.0;
+        Update( proxy.health, proxy.armor, 100u, 100u );
+    }
+
+    public func Update(hp: Uint16, armor: Uint16, maxHp: Uint16, maxArmor: Uint16) -> Void {
+        targetHpFrac = Cast<Float>(hp) / Cast<Float>(Max(1u, maxHp));
+        curHpFrac = Lerp(curHpFrac, targetHpFrac, 0.3);
+        hpBar.SetScale(new Vector2(curHpFrac, 1.0));
+        let c: HDRColor;
+        if curHpFrac > 0.5 {
+            c = HDRColor.FromLinear(new Color(1.0 - (curHpFrac - 0.5) * 2.0, 1.0, 0.0));
+        } else {
+            c = HDRColor.FromLinear(new Color(1.0, curHpFrac * 2.0, 0.0));
+        };
+        hpBar.SetTintColor(c);
+        let armorFrac: Float = Cast<Float>(armor) / Cast<Float>(Max(1u, maxArmor));
+        armorBar.SetScale(new Vector2(armorFrac, 1.0));
+        armorBar.SetTintColor(HDRColor.FromLinear(new Color(0.3, 0.5, 1.0)));
+        if curHpFrac < 0.25 {
+            widget.PlayAnimation(n"shake");
+        }
     }
 }

--- a/cp2077-coop/src/gui/HoloBars.reds
+++ b/cp2077-coop/src/gui/HoloBars.reds
@@ -1,0 +1,33 @@
+public class HoloBars extends inkHUDLayer {
+    private static let s_instance: ref<HoloBars>;
+    private let top: ref<inkRectangle>;
+    private let bottom: ref<inkRectangle>;
+
+    public static func Show() -> Void {
+        if IsDefined(s_instance) { return; };
+        let layer = new HoloBars();
+        s_instance = layer;
+        layer.top = new inkRectangle();
+        layer.top.SetSize(1920.0, 120.0);
+        layer.top.SetTintColor(new HDRColor(0.0, 0.0, 0.0, 1.0));
+        layer.top.SetAnchor(inkEAnchor.TopCenter);
+        layer.AddChild(layer.top);
+
+        layer.bottom = new inkRectangle();
+        layer.bottom.SetSize(1920.0, 120.0);
+        layer.bottom.SetTintColor(new HDRColor(0.0, 0.0, 0.0, 1.0));
+        layer.bottom.SetAnchor(inkEAnchor.BottomCenter);
+        layer.AddChild(layer.bottom);
+
+        let hud = GameInstance.GetHUDManager(GetGame());
+        // Adds cinematic black bars without pausing gameplay.
+        hud.AddLayer(layer);
+    }
+
+    public static func Hide() -> Void {
+        if !IsDefined(s_instance) { return; };
+        let hud = GameInstance.GetHUDManager(GetGame());
+        hud.RemoveLayer(s_instance);
+        s_instance = null;
+    }
+}

--- a/cp2077-coop/src/gui/MergePrompt.reds
+++ b/cp2077-coop/src/gui/MergePrompt.reds
@@ -1,0 +1,34 @@
+public class MergePrompt extends inkGameController {
+    private let listPanel: ref<inkVerticalPanel>;
+    private let conflicts: array<String>;
+
+    public func Show(conflictJson: String) -> Void {
+        conflicts = [];
+        listPanel = new inkVerticalPanel();
+        let rows = Json.Parse(conflictJson) as array<ref<IScriptable>>;
+        for r in rows {
+            let text = r as String;
+            conflicts += text;
+            let row = new inkText();
+            row.SetText(text);
+            listPanel.AddChild(row);
+        }
+        AddChild(listPanel);
+        LogChannel(n"DEBUG", "MergePrompt.Show count=" + IntToString(ArraySize(conflicts)));
+    }
+
+    public func AcceptAll() -> Void {
+        PersistResolution(true);
+    }
+
+    public func SkipEach() -> Void {
+        PersistResolution(false);
+    }
+
+    private native func SaveMergeResolution(acceptAll: Bool) -> Void
+
+    private func PersistResolution(acceptAll: Bool) -> Void {
+        SaveMergeResolution(acceptAll);
+        LogChannel(n"DEBUG", "MergePrompt.Persist acceptAll=" + BoolToString(acceptAll));
+    }
+}

--- a/cp2077-coop/src/gui/MicIcon.reds
+++ b/cp2077-coop/src/gui/MicIcon.reds
@@ -1,0 +1,22 @@
+public class MicIcon extends inkHUDLayer {
+    private static let s_instance: ref<MicIcon>;
+    private let rect: ref<inkRectangle>;
+
+    public static func Show() -> Void {
+        if IsDefined(s_instance) { return; };
+        let l = new MicIcon();
+        s_instance = l;
+        l.rect = new inkRectangle();
+        l.rect.SetSize(32.0, 32.0);
+        l.rect.SetTintColor(new HDRColor(1.0, 1.0, 1.0, 1.0));
+        l.rect.SetAnchor(inkEAnchor.BottomRight);
+        l.AddChild(l.rect);
+        GameInstance.GetHUDManager(GetGame()).AddLayer(l);
+    }
+
+    public static func Hide() -> Void {
+        if !IsDefined(s_instance) { return; };
+        GameInstance.GetHUDManager(GetGame()).RemoveLayer(s_instance);
+        s_instance = null;
+    }
+}

--- a/cp2077-coop/src/gui/SpectatorHUD.reds
+++ b/cp2077-coop/src/gui/SpectatorHUD.reds
@@ -1,0 +1,26 @@
+public class SpectatorHUD extends inkGameController {
+    private let hpText: wref<inkText>;
+    private let target: Uint32;
+
+    public func OnCreate() -> Void {
+        let root = this.GetRootWidget();
+        let c = new inkCanvas();
+        root.AddChild(c);
+        hpText = new inkText();
+        c.AddChild(hpText);
+        c.SetAnchor(inkEAnchor.CenterLeft);
+        c.SetMargin(new inkMargin(20.0, 20.0, 0.0, 0.0));
+    }
+
+    public func SetTarget(id: Uint32) -> Void {
+        target = id;
+    }
+
+    public func OnUpdate(dt: Float) -> Void {
+        if target == 0u { return; };
+        let avatar = GameInstance.GetPlayerSystem(GetGame()).FindObject(target) as AvatarProxy;
+        if IsDefined(avatar) {
+            hpText.SetText("HP: " + IntToString(avatar.health));
+        };
+    }
+}

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -1,17 +1,25 @@
 #include "Connection.hpp"
+#include "../core/GameClock.hpp"
+#include "../core/Hash.hpp"
+#include "../core/SessionState.hpp"
+#include "../runtime/GameModeManager.reds"
+#include "../server/BreachController.hpp"
+#include "../server/NpcController.hpp"
+#include "../voice/VoiceDecoder.hpp"
+#include "Net.hpp"
 #include "StatBatch.hpp"
-#include <iostream> // RED4ext logger stub
-
+#include <RED4ext/RED4ext.hpp>
+#include <iostream>
 
 // Temporary proxies for script methods.
-static void AvatarProxy_Spawn(uint32_t peerId, bool isLocal)
+static void AvatarProxy_SpawnRemote(uint32_t peerId, bool isLocal, const CoopNet::TransformSnap& snap)
 {
-    std::cout << "AvatarProxy::Spawn " << peerId << " local=" << isLocal << std::endl;
+    RED4ext::ExecuteFunction("AvatarProxy", "SpawnRemote", nullptr, peerId, isLocal, &snap);
 }
 
-static void AvatarProxy_Despawn(uint32_t peerId)
+static void AvatarProxy_DespawnRemote(uint32_t peerId)
 {
-    std::cout << "AvatarProxy::Despawn " << peerId << std::endl;
+    RED4ext::ExecuteFunction("AvatarProxy", "DespawnRemote", nullptr, peerId);
 }
 
 static void Killfeed_Push(const char* msg)
@@ -21,8 +29,8 @@ static void Killfeed_Push(const char* msg)
 
 static void ChatOverlay_Push(const char* msg)
 {
-    // TODO(next ticket): invoke ChatOverlay.PushGlobal via RTTI
-    std::cout << "Chat: " << msg << std::endl;
+    RED4ext::CString s(msg);
+    RED4ext::ExecuteFunction("ChatOverlay", "PushGlobal", nullptr, &s);
 }
 
 static void QuestSync_ApplyQuestStage(const char* name)
@@ -40,6 +48,150 @@ static void DMScoreboard_OnScorePacket(uint32_t peerId, uint16_t k, uint16_t d)
     std::cout << "ScoreUpdate " << peerId << " " << k << "/" << d << std::endl;
 }
 
+static void DMScoreboard_OnMatchOver(uint32_t winner)
+{
+    std::cout << "MatchOver " << winner << std::endl;
+}
+
+static void NpcProxy_Spawn(const CoopNet::NpcSnap& snap)
+{
+    CoopNet::NpcController_ClientApplySnap(snap);
+}
+
+static void NpcProxy_Despawn(uint32_t npcId)
+{
+    CoopNet::NpcController_Despawn(npcId);
+}
+
+static void NpcProxy_ApplySnap(const CoopNet::NpcSnap& snap)
+{
+    CoopNet::NpcController_ClientApplySnap(snap);
+}
+
+static void Cutscene_OnCineStart(uint32_t sceneId, uint32_t startMs)
+{
+    CutsceneSync_CineStart(sceneId, startMs);
+}
+
+static void Cutscene_OnViseme(uint32_t npcId, uint8_t visemeId, uint32_t timeMs)
+{
+    CutsceneSync_Viseme(npcId, visemeId, timeMs);
+}
+
+static void Cutscene_OnDialogChoice(uint32_t peerId, uint8_t idx)
+{
+    CutsceneSync_DialogChoice(peerId, idx);
+}
+
+static void Inventory_OnItemSnap(const CoopNet::ItemSnap& snap)
+{
+    std::cout << "ItemSnap " << snap.itemId << std::endl;
+}
+
+static void Inventory_OnCraftResult(const CoopNet::ItemSnap& snap)
+{
+    std::cout << "CraftResult item=" << snap.itemId << std::endl;
+}
+
+static void Inventory_OnAttachResult(const CoopNet::ItemSnap& snap, bool success)
+{
+    std::cout << "AttachResult item=" << snap.itemId << " success=" << success << std::endl;
+}
+
+static void Inventory_OnPurchaseResult(uint64_t itemId, uint64_t balance, bool success)
+{
+    RED4ext::ExecuteFunction("Inventory", "OnPurchaseResult", nullptr, &itemId, &balance, &success);
+}
+
+static void AvatarProxy_OnSectorChange(uint32_t peerId, uint64_t hash)
+{
+    std::cout << "SectorChange " << peerId << " -> " << hash << std::endl;
+}
+
+static void VehicleProxy_Explode(uint32_t id, uint32_t vfx, uint32_t seed)
+{
+    std::cout << "Vehicle explode " << id << " vfx=" << vfx << " seed=" << seed << std::endl;
+}
+
+static void VehicleProxy_Detach(uint32_t id, uint8_t part)
+{
+    std::cout << "Vehicle detach " << id << " part " << static_cast<int>(part) << std::endl;
+}
+
+static void AvatarProxy_OnEject(uint32_t peerId, const RED4ext::Vector3& vel)
+{
+    std::cout << "Eject occupant " << peerId << " vel=" << vel.X << "," << vel.Y << "," << vel.Z << std::endl;
+}
+
+static void BreachHud_Start(uint32_t peerId, uint32_t seed, uint8_t w, uint8_t h)
+{
+    std::cout << "Breach start seed=" << seed << " w=" << static_cast<int>(w) << " h=" << static_cast<int>(h)
+              << std::endl;
+}
+
+static void BreachHud_Input(uint32_t peerId, uint8_t idx)
+{
+    std::cout << "Breach input peer=" << peerId << " idx=" << static_cast<int>(idx) << std::endl;
+}
+
+static void Quickhack_BreachResult(uint32_t peerId, uint8_t mask)
+{
+    std::cout << "Breach result mask=" << static_cast<int>(mask) << std::endl;
+}
+
+static void VendorSync_OnStock(const CoopNet::VendorStockPacket& pkt)
+{
+    RED4ext::ExecuteFunction("VendorSync", "OnStock", nullptr, &pkt);
+}
+
+static void HeatSync_Apply(uint8_t level)
+{
+    std::cout << "Heat level " << static_cast<int>(level) << std::endl;
+}
+
+static void WeatherSync_Apply(const CoopNet::WorldStatePacket& pkt)
+{
+    std::cout << "World clock=" << pkt.worldClockMs << " weather=" << static_cast<int>(pkt.weatherId) << std::endl;
+}
+
+static void GlobalEvent_OnPacket(const CoopNet::GlobalEventPacket& pkt)
+{
+    std::cout << "Event " << pkt.eventId << " phase=" << static_cast<int>(pkt.phase) << (pkt.start ? " start" : " stop")
+              << std::endl;
+}
+
+static void SpectatorCam_Enter(uint32_t peerId)
+{
+    std::cout << "Enter spectate " << peerId << std::endl;
+}
+
+static void ElevatorSync_OnArrive(uint32_t id, uint64_t hash, const RED4ext::Vector3& pos)
+{
+    (void)id;
+    (void)hash;
+    (void)pos;
+}
+
+static void UIPauseAudit_OnHoloStart(uint32_t peerId)
+{
+    std::cout << "HoloCall start " << peerId << std::endl;
+}
+
+static void UIPauseAudit_OnHoloEnd(uint32_t peerId)
+{
+    std::cout << "HoloCall end " << peerId << std::endl;
+}
+
+static void GameModeManager_SetFriendlyFire(bool enable)
+{
+    std::cout << "FriendlyFire=" << (enable ? "true" : "false") << std::endl;
+}
+
+static void SnapshotInterpolator_OnTickRateChange(uint16_t ms)
+{
+    std::cout << "TickRateChange " << ms << " ms" << std::endl;
+}
+
 namespace CoopNet
 {
 
@@ -47,7 +199,30 @@ Connection::Connection()
     : state(ConnectionState::Disconnected)
     , lastPingSent(0)
     , lastRecvTime(0)
+    , avatarPos{0.f, 0.f, 0.f}
+    , currentSector(0)
+    , sectorReady(true)
+    , rttHist{}
+    , rttIndex(0)
 {
+}
+
+void Connection::SendSectorChange(uint64_t hash)
+{
+    SectorChangePacket pkt{0u, hash};
+    Net_Send(this, EMsg::SectorChange, &pkt, sizeof(pkt));
+    CoopNet::NpcController_OnPlayerEnterSector(peerId, hash);
+    sectorReady = false;
+    currentSector = hash;
+    lastSectorChangeTick = CoopNet::GameClock::GetCurrentTick();
+}
+
+void Connection::SendSectorReady(uint64_t hash)
+{
+    SectorReadyPacket pkt{hash};
+    Net_Send(this, EMsg::SectorReady, &pkt, sizeof(pkt));
+    sectorReady = true;
+    currentSector = hash;
 }
 
 void Connection::StartHandshake()
@@ -61,6 +236,24 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
     (void)size;
     switch (static_cast<EMsg>(hdr.type))
     {
+    case EMsg::Ping:
+        if (size >= sizeof(PingPacket))
+        {
+            const PingPacket* pkt = reinterpret_cast<const PingPacket*>(payload);
+            PongPacket pong{pkt->timeMs};
+            Net_Send(this, EMsg::Pong, &pong, sizeof(pong));
+        }
+        break;
+    case EMsg::Pong:
+        if (size >= sizeof(PongPacket))
+        {
+            const PongPacket* pkt = reinterpret_cast<const PongPacket*>(payload);
+            uint64_t now = GameClock::GetTimeMs();
+            rttMs = static_cast<float>(now - pkt->timeMs);
+            rttHist[rttIndex % 16] = rttMs;
+            rttIndex = (rttIndex + 1) % 16;
+        }
+        break;
     case EMsg::Welcome:
         if (state == ConnectionState::Handshaking)
         {
@@ -71,33 +264,391 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         if (state == ConnectionState::Lobby)
         {
             Transition(ConnectionState::InGame);
+            uint64_t hash = CoopNet::Fnv1a64Pos(avatarPos.X, avatarPos.Y);
+            SectorChangePacket pkt{0u, hash};
+            Net_Send(this, EMsg::SectorChange, &pkt, sizeof(pkt));
+            std::vector<uint32_t> ids;
+            for (auto* c : Net_GetConnections())
+                ids.push_back(c->peerId);
+            CoopNet::SessionState_SetParty(ids);
         }
         break;
     case EMsg::Disconnect:
         Killfeed_Push("0 disconnected");
+        CoopNet::VehicleController_RemovePeer(peerId);
         Transition(ConnectionState::Disconnected);
+        CoopNet::SaveSessionState(CoopNet::SessionState_GetId());
         break;
     case EMsg::AvatarSpawn:
-        AvatarProxy_Spawn(0, false); // FIXME(next ticket: parse payload)
+        if (size >= sizeof(AvatarSpawnPacket))
+        {
+            const AvatarSpawnPacket* pkt = reinterpret_cast<const AvatarSpawnPacket*>(payload);
+            AvatarProxy_SpawnRemote(pkt->peerId, pkt->peerId == 0, pkt->snap);
+            avatarPos = pkt->snap.pos;
+            uint64_t hash = CoopNet::Fnv1a64Pos(avatarPos.X, avatarPos.Y);
+            currentSector = hash;
+            SectorChangePacket sp{pkt->peerId, hash};
+            Net_Send(this, EMsg::SectorChange, &sp, sizeof(sp));
+        }
         break;
     case EMsg::AvatarDespawn:
-        AvatarProxy_Despawn(0); // FIXME(next ticket: parse payload)
+        if (size >= sizeof(AvatarDespawnPacket))
+        {
+            const AvatarDespawnPacket* pkt = reinterpret_cast<const AvatarDespawnPacket*>(payload);
+            AvatarProxy_DespawnRemote(pkt->peerId);
+        }
         Killfeed_Push("0 disconnected");
         break;
     case EMsg::Chat:
-        ChatOverlay_Push("peer: msg"); // FIXME(next ticket: parse payload)
+        if (Net_IsAuthoritative())
+        {
+            if (CoopNet::GameClock::GetTimeMs() < muteUntilMs)
+                break;
+            if (size >= sizeof(ChatPacket))
+            {
+                const ChatPacket* pkt = reinterpret_cast<const ChatPacket*>(payload);
+                ChatPacket out{peerId, {0}};
+                std::strncpy(out.msg, pkt->msg, sizeof(out.msg) - 1);
+                Net_Broadcast(EMsg::Chat, &out, sizeof(out));
+            }
+        }
+        if (size >= sizeof(ChatPacket))
+        {
+            const ChatPacket* pkt = reinterpret_cast<const ChatPacket*>(payload);
+            ChatOverlay_Push(pkt->msg);
+        }
         break;
     case EMsg::QuestStage:
-        QuestSync_ApplyQuestStage(n"stubQuest"); // FIXME(next ticket: parse payload)
+        QuestSync_ApplyQuestStage(n "tempQuest"); // P4-1: parse payload
         break;
     case EMsg::SceneTrigger:
-        QuestSync_ApplySceneTrigger("0", true); // FIXME(next ticket: parse payload)
+        QuestSync_ApplySceneTrigger("0", true); // P4-2: parse payload
+        break;
+    case EMsg::NpcSpawn:
+        if (size >= sizeof(NpcSpawnPacket))
+        {
+            const NpcSpawnPacket* pkt = reinterpret_cast<const NpcSpawnPacket*>(payload);
+            NpcProxy_Spawn(pkt->snap);
+        }
+        break;
+    case EMsg::NpcSnapshot:
+        if (size >= sizeof(NpcSnapshotPacket))
+        {
+            const NpcSnapshotPacket* pkt = reinterpret_cast<const NpcSnapshotPacket*>(payload);
+            NpcProxy_ApplySnap(pkt->snap);
+        }
+        break;
+    case EMsg::NpcDespawn:
+        if (size >= sizeof(NpcDespawnPacket))
+        {
+            const NpcDespawnPacket* pkt = reinterpret_cast<const NpcDespawnPacket*>(payload);
+            NpcProxy_Despawn(pkt->npcId);
+        }
+        break;
+    case EMsg::SectorChange:
+        if (size >= sizeof(SectorChangePacket))
+        {
+            const SectorChangePacket* pkt = reinterpret_cast<const SectorChangePacket*>(payload);
+            AvatarProxy_OnSectorChange(pkt->peerId, pkt->sectorHash);
+            sectorReady = false;
+            currentSector = pkt->sectorHash;
+            lastSectorChangeTick = CoopNet::GameClock::GetCurrentTick();
+            // Ack will be sent from OnStreamingDone hook.
+        }
+        break;
+    case EMsg::SectorReady:
+        if (size >= sizeof(SectorReadyPacket))
+        {
+            const SectorReadyPacket* pkt = reinterpret_cast<const SectorReadyPacket*>(payload);
+            sectorReady = true;
+            currentSector = pkt->sectorHash;
+        }
         break;
     case EMsg::ScoreUpdate:
         if (size >= sizeof(ScoreUpdatePacket))
         {
             const ScoreUpdatePacket* pkt = reinterpret_cast<const ScoreUpdatePacket*>(payload);
             DMScoreboard_OnScorePacket(pkt->peerId, pkt->k, pkt->d);
+        }
+        break;
+    case EMsg::MatchOver:
+        if (size >= sizeof(MatchOverPacket))
+        {
+            const MatchOverPacket* pkt = reinterpret_cast<const MatchOverPacket*>(payload);
+            DMScoreboard_OnMatchOver(pkt->winnerId);
+        }
+        break;
+    case EMsg::ItemSnap:
+        if (size >= sizeof(ItemSnapPacket))
+        {
+            const ItemSnapPacket* pkt = reinterpret_cast<const ItemSnapPacket*>(payload);
+            Inventory_OnItemSnap(pkt->snap);
+        }
+        break;
+    case EMsg::CraftResult:
+        if (size >= sizeof(CraftResultPacket))
+        {
+            const CraftResultPacket* pkt = reinterpret_cast<const CraftResultPacket*>(payload);
+            Inventory_OnCraftResult(pkt->item);
+        }
+        break;
+    case EMsg::AttachModResult:
+        if (size >= sizeof(AttachModResultPacket))
+        {
+            const AttachModResultPacket* pkt = reinterpret_cast<const AttachModResultPacket*>(payload);
+            Inventory_OnAttachResult(pkt->item, pkt->success != 0);
+        }
+        break;
+    case EMsg::HeatSync:
+        if (size >= sizeof(HeatPacket))
+        {
+            const HeatPacket* pkt = reinterpret_cast<const HeatPacket*>(payload);
+            HeatSync_Apply(pkt->level);
+        }
+        break;
+    case EMsg::WorldState:
+        if (size >= sizeof(WorldStatePacket))
+        {
+            const WorldStatePacket* pkt = reinterpret_cast<const WorldStatePacket*>(payload);
+            WeatherSync_Apply(*pkt);
+        }
+        break;
+    case EMsg::VehicleExplode:
+        if (size >= sizeof(VehicleExplodePacket))
+        {
+            const VehicleExplodePacket* pkt = reinterpret_cast<const VehicleExplodePacket*>(payload);
+            VehicleProxy_Explode(pkt->vehicleId, pkt->vfxId, pkt->seed);
+        }
+        break;
+    case EMsg::VehiclePartDetach:
+        if (size >= sizeof(VehiclePartDetachPacket))
+        {
+            const VehiclePartDetachPacket* pkt = reinterpret_cast<const VehiclePartDetachPacket*>(payload);
+            VehicleProxy_Detach(pkt->vehicleId, pkt->partId);
+        }
+        break;
+    case EMsg::VehicleSpawn:
+        if (size >= sizeof(VehicleSpawnPacket))
+        {
+            const VehicleSpawnPacket* pkt = reinterpret_cast<const VehicleSpawnPacket*>(payload);
+            VehicleProxy_Spawn(pkt->vehicleId, &pkt->transform);
+        }
+        break;
+    case EMsg::SeatAssign:
+        if (size >= sizeof(SeatAssignPacket))
+        {
+            const SeatAssignPacket* pkt = reinterpret_cast<const SeatAssignPacket*>(payload);
+            VehicleProxy_EnterSeat(pkt->peerId, pkt->seatIdx);
+        }
+        break;
+    case EMsg::VehicleHit:
+        if (size >= sizeof(VehicleHitPacket))
+        {
+            const VehicleHitPacket* pkt = reinterpret_cast<const VehicleHitPacket*>(payload);
+            VehicleProxy_ApplyDamage(pkt->vehicleId, pkt->dmg, pkt->side != 0);
+        }
+        break;
+    case EMsg::SeatRequest:
+        if (size >= sizeof(SeatRequestPacket) && Net_IsAuthoritative())
+        {
+            const SeatRequestPacket* pkt = reinterpret_cast<const SeatRequestPacket*>(payload);
+            CoopNet::VehicleController_HandleSeatRequest(this, pkt->vehicleId, pkt->seatIdx);
+        }
+        break;
+    case EMsg::EjectOccupant:
+        if (size >= sizeof(EjectOccupantPacket))
+        {
+            const EjectOccupantPacket* pkt = reinterpret_cast<const EjectOccupantPacket*>(payload);
+            AvatarProxy_OnEject(pkt->peerId, pkt->velocity);
+        }
+        break;
+    case EMsg::BreachStart:
+        if (size >= sizeof(BreachStartPacket))
+        {
+            const BreachStartPacket* pkt = reinterpret_cast<const BreachStartPacket*>(payload);
+            BreachHud_Start(pkt->peerId, pkt->seed, pkt->gridW, pkt->gridH);
+        }
+        break;
+    case EMsg::BreachInput:
+        if (size >= sizeof(BreachInputPacket))
+        {
+            const BreachInputPacket* pkt = reinterpret_cast<const BreachInputPacket*>(payload);
+            BreachHud_Input(pkt->peerId, pkt->index);
+            if (Net_IsAuthoritative())
+                CoopNet::BreachController_HandleInput(pkt->peerId, pkt->index);
+        }
+        break;
+    case EMsg::BreachResult:
+        if (size >= sizeof(BreachResultPacket))
+        {
+            const BreachResultPacket* pkt = reinterpret_cast<const BreachResultPacket*>(payload);
+            Quickhack_BreachResult(pkt->peerId, pkt->daemonsMask);
+        }
+        break;
+    case EMsg::ElevatorCall:
+        if (size >= sizeof(ElevatorCallPacket))
+        {
+            const ElevatorCallPacket* pkt = reinterpret_cast<const ElevatorCallPacket*>(payload);
+            if (Net_IsAuthoritative())
+                CoopNet::ElevatorController_OnCall(pkt->peerId, pkt->elevatorId, pkt->floorIdx);
+        }
+        break;
+    case EMsg::ElevatorArrive:
+        if (size >= sizeof(ElevatorArrivePacket))
+        {
+            const ElevatorArrivePacket* pkt = reinterpret_cast<const ElevatorArrivePacket*>(payload);
+            ElevatorSync_OnArrive(pkt->elevatorId, pkt->sectorHash, pkt->pos);
+        }
+        break;
+    case EMsg::TeleportAck:
+        if (size >= sizeof(TeleportAckPacket) && Net_IsAuthoritative())
+        {
+            const TeleportAckPacket* pkt = reinterpret_cast<const TeleportAckPacket*>(payload);
+            CoopNet::ElevatorController_OnAck(this, pkt->elevatorId);
+        }
+        break;
+    case EMsg::HoloCallStart:
+        if (size >= sizeof(HoloCallPacket))
+        {
+            const HoloCallPacket* pkt = reinterpret_cast<const HoloCallPacket*>(payload);
+            UIPauseAudit_OnHoloStart(pkt->peerId);
+        }
+        break;
+    case EMsg::HoloCallEnd:
+        if (size >= sizeof(HoloCallPacket))
+        {
+            const HoloCallPacket* pkt = reinterpret_cast<const HoloCallPacket*>(payload);
+            UIPauseAudit_OnHoloEnd(pkt->peerId);
+        }
+        break;
+    case EMsg::SpectateRequest:
+        if (size >= sizeof(SpectatePacket) && Net_IsAuthoritative())
+        {
+            const SpectatePacket* pkt = reinterpret_cast<const SpectatePacket*>(payload);
+            Net_SendSpectateGranted(pkt->peerId);
+        }
+        break;
+    case EMsg::SpectateGranted:
+        if (size >= sizeof(SpectatePacket))
+        {
+            const SpectatePacket* pkt = reinterpret_cast<const SpectatePacket*>(payload);
+            SpectatorCam_Enter(pkt->peerId);
+        }
+        break;
+    case EMsg::NatCandidate:
+        if (size >= sizeof(NatCandidatePacket))
+        {
+            const NatCandidatePacket* pkt = reinterpret_cast<const NatCandidatePacket*>(payload);
+            CoopNet::Nat_AddRemoteCandidate(pkt->sdp);
+            CoopNet::Nat_PerformHandshake(this);
+        }
+        break;
+    case EMsg::CineStart:
+        if (size >= sizeof(CineStartPacket))
+        {
+            const CineStartPacket* pkt = reinterpret_cast<const CineStartPacket*>(payload);
+            Cutscene_OnCineStart(pkt->sceneId, pkt->startTimeMs);
+        }
+        break;
+    case EMsg::Viseme:
+        if (size >= sizeof(VisemePacket))
+        {
+            const VisemePacket* pkt = reinterpret_cast<const VisemePacket*>(payload);
+            Cutscene_OnViseme(pkt->npcId, pkt->visemeId, pkt->timeMs);
+        }
+        break;
+    case EMsg::DialogChoice:
+        if (size >= sizeof(DialogChoicePacket))
+        {
+            const DialogChoicePacket* pkt = reinterpret_cast<const DialogChoicePacket*>(payload);
+            uint32_t sender = Net_IsAuthoritative() ? peerId : pkt->peerId;
+            Cutscene_OnDialogChoice(sender, pkt->choiceIdx);
+            if (Net_IsAuthoritative())
+                Net_BroadcastDialogChoice(sender, pkt->choiceIdx);
+        }
+        break;
+    case EMsg::Voice:
+        if (size >= sizeof(VoicePacket))
+        {
+            const VoicePacket* pkt = reinterpret_cast<const VoicePacket*>(payload);
+            if (Net_IsAuthoritative())
+            {
+                Net_BroadcastVoice(peerId, pkt->data, pkt->size, pkt->seq);
+            }
+            else
+            {
+                CoopVoice::PushPacket(pkt->seq, pkt->data, pkt->size);
+            }
+        }
+        break;
+    case EMsg::GlobalEvent:
+        if (size >= sizeof(GlobalEventPacket))
+        {
+            const GlobalEventPacket* pkt = reinterpret_cast<const GlobalEventPacket*>(payload);
+            GlobalEvent_OnPacket(*pkt);
+        }
+        break;
+    case EMsg::CrowdSeed:
+        if (size >= sizeof(CrowdSeedPacket))
+        {
+            const CrowdSeedPacket* pkt = reinterpret_cast<const CrowdSeedPacket*>(payload);
+            NpcController_ApplyCrowdSeed(pkt->sectorHash, pkt->seed);
+        }
+        break;
+    case EMsg::VendorStock:
+        if (size >= sizeof(VendorStockPacket))
+        {
+            const VendorStockPacket* pkt = reinterpret_cast<const VendorStockPacket*>(payload);
+            VendorSync_OnStock(*pkt);
+        }
+        break;
+    case EMsg::AdminCmd:
+        if (size >= sizeof(AdminCmdPacket))
+        {
+            const AdminCmdPacket* pkt = reinterpret_cast<const AdminCmdPacket*>(payload);
+            std::cout << "AdminCmd type=" << static_cast<int>(pkt->cmdType) << " param=" << pkt->param << std::endl;
+        }
+        break;
+    case EMsg::TickRateChange:
+        if (size >= sizeof(TickRateChangePacket))
+        {
+            const TickRateChangePacket* pkt = reinterpret_cast<const TickRateChangePacket*>(payload);
+            SnapshotInterpolator_OnTickRateChange(pkt->tickMs);
+        }
+        break;
+    case EMsg::RuleChange:
+        if (size >= sizeof(RuleChangePacket))
+        {
+            const RuleChangePacket* pkt = reinterpret_cast<const RuleChangePacket*>(payload);
+            GameModeManager_SetFriendlyFire(pkt->friendlyFire != 0u);
+        }
+        break;
+    case EMsg::CraftRequest:
+        if (size >= sizeof(CraftRequestPacket) && Net_IsAuthoritative())
+        {
+            const CraftRequestPacket* pkt = reinterpret_cast<const CraftRequestPacket*>(payload);
+            CoopNet::Inventory_HandleCraftRequest(this, pkt->recipeId);
+        }
+        break;
+    case EMsg::AttachModRequest:
+        if (size >= sizeof(AttachModRequestPacket) && Net_IsAuthoritative())
+        {
+            const AttachModRequestPacket* pkt = reinterpret_cast<const AttachModRequestPacket*>(payload);
+            CoopNet::Inventory_HandleAttachRequest(this, pkt->itemId, pkt->slotIdx, pkt->attachmentId);
+        }
+        break;
+    case EMsg::PurchaseRequest:
+        if (size >= sizeof(PurchaseRequestPacket) && Net_IsAuthoritative())
+        {
+            const PurchaseRequestPacket* pkt = reinterpret_cast<const PurchaseRequestPacket*>(payload);
+            CoopNet::VendorController_HandlePurchase(this, pkt->vendorId, pkt->itemId, pkt->nonce);
+        }
+        break;
+    case EMsg::PurchaseResult:
+        if (size >= sizeof(PurchaseResultPacket) && !Net_IsAuthoritative())
+        {
+            const PurchaseResultPacket* pkt = reinterpret_cast<const PurchaseResultPacket*>(payload);
+            Inventory_OnPurchaseResult(pkt->itemId, pkt->balance, pkt->success != 0);
         }
         break;
     default:
@@ -107,22 +658,41 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
 
 void Connection::Update(uint64_t nowMs)
 {
-    // Store ping timestamp; actual ping logic will come later.
-    lastPingSent = nowMs;
+    if (nowMs - lastPingSent >= 5000)
+    {
+        PingPacket ping{static_cast<uint32_t>(nowMs & 0xFFFFFFFFu)};
+        Net_Send(this, EMsg::Ping, &ping, sizeof(ping));
+        lastPingSent = nowMs;
+    }
 
     RawPacket pkt;
     while (m_incoming.Pop(pkt))
     {
         HandlePacket(pkt.hdr, pkt.data.data(), static_cast<uint16_t>(pkt.data.size()));
     }
-    // At end of tick loop, send any batched score packets.
-    CoopNet::FlushStats();
+
+    int16_t pcm[960];
+    if (CoopVoice::DecodeFrame(pcm) > 0)
+    {
+        // PCM would be sent to audio output here
+    }
+
+    if (!sectorReady)
+    {
+        const uint64_t timeoutTicks = static_cast<uint64_t>(10000.f / CoopNet::kVehicleStepMs);
+        if (CoopNet::GameClock::GetCurrentTick() - lastSectorChangeTick > timeoutTicks)
+        {
+            std::cout << "SectorReady timeout" << std::endl;
+            sectorReady = true;
+        }
+    }
+    CoopNet::StatBatch_Tick(static_cast<float>(CoopNet::GameClock::GetTickMs()) / 1000.f);
 }
 
 void Connection::EnqueuePacket(const RawPacket& pkt)
 {
     m_incoming.Push(pkt);
-    lastRecvTime = 0; // activity timestamp placeholder
+    lastRecvTime = 0; // NT-2: track activity time
 }
 
 bool Connection::PopPacket(RawPacket& out)
@@ -140,4 +710,3 @@ void Connection::Transition(ConnectionState next)
 }
 
 } // namespace CoopNet
-

--- a/cp2077-coop/src/net/Connection.hpp
+++ b/cp2077-coop/src/net/Connection.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include <cstdint>
-#include <vector>
 #include "Packets.hpp"
 #include "core/ThreadSafeQueue.hpp"
+#include <RED4ext/Scripting/Natives/Generated/Vector3.hpp>
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
 
 namespace CoopNet
 {
@@ -34,7 +36,13 @@ public:
 
     bool PopPacket(RawPacket& out);
 
-    ConnectionState GetState() const { return state; }
+    void SendSectorChange(uint64_t hash);
+    void SendSectorReady(uint64_t hash);
+
+    ConnectionState GetState() const
+    {
+        return state;
+    }
 
 private:
     void Transition(ConnectionState next);
@@ -44,7 +52,21 @@ private:
 public:
     uint64_t lastPingSent;
     uint64_t lastRecvTime;
+    uint32_t peerId = 0;
+    uint64_t muteUntilMs = 0;
+    RED4ext::Vector3 avatarPos;
+    uint64_t currentSector = 0;
+    bool sectorReady = true;
+    uint64_t lastSectorChangeTick = 0;
+    std::unordered_set<uint32_t> subscribedNpcs;
+    uint64_t relayBytes = 0;
+    bool usingRelay = false;
+    float rttMs = 0.f;
+    float rttHist[16]{};
+    uint8_t rttIndex = 0;
+    float packetLoss = 0.f;
+    uint64_t balance = 10000;
+    uint64_t lastNonce = 0;
 };
 
 } // namespace CoopNet
-

--- a/cp2077-coop/src/net/NatClient.cpp
+++ b/cp2077-coop/src/net/NatClient.cpp
@@ -1,0 +1,152 @@
+#include "NatClient.hpp"
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+namespace CoopNet
+{
+static CandidateCallback g_callback;
+static juice_agent_t* g_agent = nullptr;
+static std::string g_remoteCandidate;
+static bool g_connected = false;
+static uint64_t g_relayBytes = 0;
+static std::string g_turnHost;
+static int g_turnPort = 0;
+static std::string g_turnUser;
+static std::string g_turnPass;
+static bool g_haveTurn = false;
+
+void Nat_SetCandidateCallback(CandidateCallback cb)
+{
+    g_callback = cb;
+}
+
+void Nat_Start()
+{
+    juice_agent_config_t cfg = JUICE_AGENT_CONFIG_DEFAULT;
+    cfg.stun_server_host = "stun.l.google.com";
+    cfg.stun_server_port = 19302;
+    cfg.cb_candidate = [](juice_agent_t*, const char* sdp, void*) {
+        if (g_callback)
+            g_callback(sdp);
+    };
+    cfg.cb_state_changed = [](juice_agent_t*, juice_state_t state, void*) {
+        if (state == JUICE_STATE_CONNECTED)
+            g_connected = true;
+    };
+    if (juice_create(&cfg, &g_agent) != 0)
+    {
+        std::cerr << "juice_create failed" << std::endl;
+        return;
+    }
+    juice_gather_candidates(g_agent);
+}
+
+static bool RequestTurnCreds(std::string& host, int& port,
+                             std::string& user, std::string& pass)
+{
+    if (!g_haveTurn)
+        return false;
+    host = g_turnHost;
+    port = g_turnPort;
+    user = g_turnUser;
+    pass = g_turnPass;
+    return true;
+}
+
+uint64_t Nat_GetRelayBytes()
+{
+    return g_relayBytes;
+}
+
+void Nat_PerformHandshake(Connection* conn)
+{
+    if (!conn)
+        return;
+
+    std::cout << "Nat_PerformHandshake" << std::endl;
+    g_connected = false;
+    g_relayBytes = 0;
+    if (g_agent && !g_remoteCandidate.empty())
+    {
+        juice_set_remote_description(g_agent, g_remoteCandidate.c_str());
+        juice_connect(g_agent);
+    auto start = std::chrono::steady_clock::now();
+    while (!g_connected)
+    {
+            juice_poll(g_agent);
+            if (std::chrono::steady_clock::now() - start > std::chrono::seconds(5))
+            {
+                std::cout << "ICE failed, trying TURN" << std::endl;
+                std::string host, user, pass;
+                int port = 0;
+                if (RequestTurnCreds(host, port, user, pass))
+                {
+                    juice_destroy(g_agent);
+                    juice_agent_config_t cfg = JUICE_AGENT_CONFIG_DEFAULT;
+                    cfg.stun_server_host = "stun.l.google.com";
+                    cfg.stun_server_port = 19302;
+                    cfg.turn_server_host = host.c_str();
+                    cfg.turn_server_port = port;
+                    cfg.turn_username = user.c_str();
+                    cfg.turn_password = pass.c_str();
+                    cfg.cb_candidate = [](juice_agent_t*, const char* sdp, void*) {
+                        if (g_callback)
+                            g_callback(sdp);
+                    };
+                    cfg.cb_state_changed = [](juice_agent_t*, juice_state_t state, void*) {
+                        if (state == JUICE_STATE_CONNECTED)
+                            g_connected = true;
+                    };
+                    if (juice_create(&cfg, &g_agent) == 0)
+                    {
+                        juice_set_remote_description(g_agent, g_remoteCandidate.c_str());
+                        juice_connect(g_agent);
+                        start = std::chrono::steady_clock::now();
+                    }
+                }
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        if (g_connected && conn)
+        {
+            // Placeholder bandwidth accounting
+            g_relayBytes += 5000; // NT-3: obtain stats from libjuice
+            conn->relayBytes += g_relayBytes;
+            conn->rttMs = std::chrono::duration<float, std::milli>(std::chrono::steady_clock::now() - start).count();
+            conn->usingRelay = g_relayBytes > 0;
+            std::cout << "TURN relay bytes=" << conn->relayBytes << std::endl;
+        }
+    }
+}
+
+void Nat_AddRemoteCandidate(const char* cand)
+{
+    if (cand)
+        g_remoteCandidate = cand;
+}
+
+void Nat_SetTurnCreds(const std::string& host, int port,
+                      const std::string& user, const std::string& pass)
+{
+    g_turnHost = host;
+    g_turnPort = port;
+    g_turnUser = user;
+    g_turnPass = pass;
+    g_haveTurn = true;
+}
+
+bool Nat_GetTurnCreds(std::string& host, int& port,
+                      std::string& user, std::string& pass)
+{
+    if (!g_haveTurn)
+        return false;
+    host = g_turnHost;
+    port = g_turnPort;
+    user = g_turnUser;
+    pass = g_turnPass;
+    return true;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/net/NatClient.hpp
+++ b/cp2077-coop/src/net/NatClient.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <functional>
+#include <juice/juice.h>
+
+namespace CoopNet
+{
+using CandidateCallback = std::function<void(const char*)>;
+
+void Nat_SetCandidateCallback(CandidateCallback cb);
+void Nat_Start();
+class Connection;
+
+void Nat_PerformHandshake(Connection* conn);
+
+uint64_t Nat_GetRelayBytes();
+void Nat_AddRemoteCandidate(const char* cand);
+
+void Nat_SetTurnCreds(const std::string& host, int port,
+                      const std::string& user, const std::string& pass);
+bool Nat_GetTurnCreds(std::string& host, int& port,
+                      std::string& user, std::string& pass);
+}

--- a/cp2077-coop/src/net/Net.cpp
+++ b/cp2077-coop/src/net/Net.cpp
@@ -1,25 +1,31 @@
 #include "Net.hpp"
+#include "../core/Hash.hpp"
+#include "../server/AdminController.hpp"
 #include "Connection.hpp"
+#include "NatClient.hpp"
 #include "NetConfig.hpp"
+#include "Packets.hpp"
+#include <algorithm>
+#include <cstring>
 #include <enet/enet.h>
 #include <iostream>
 #include <vector>
-#include <algorithm>
-#include <cstring>
 
 using CoopNet::Connection;
 
 namespace
 {
-    struct PeerEntry
-    {
-        ENetPeer* peer;
-        Connection* conn;
-    };
+struct PeerEntry
+{
+    ENetPeer* peer;
+    Connection* conn;
+};
 
-    ENetHost* g_Host = nullptr;
-    std::vector<PeerEntry> g_Peers;
-}
+ENetHost* g_Host = nullptr;
+std::vector<PeerEntry> g_Peers;
+static uint32_t g_nextPeerId = 1;
+// Helper used by world streaming to match sector hashing in the game.
+} // namespace
 
 void Net_Init()
 {
@@ -30,6 +36,13 @@ void Net_Init()
     }
 
     g_Host = enet_host_create(nullptr, 8, 2, 0, 0);
+    Nat_SetCandidateCallback(
+        [](const char* cand)
+        {
+            std::cout << "Local candidate: " << cand << std::endl;
+            Net_BroadcastNatCandidate(cand);
+        });
+    Nat_Start();
     std::cout << "Net_Init complete" << std::endl;
 }
 
@@ -68,13 +81,25 @@ void Net_Poll(uint32_t maxMs)
             PeerEntry e;
             e.peer = evt.peer;
             e.conn = new Connection();
-            g_Peers.push_back(e);
-            std::cout << "peer connected" << std::endl;
+            e.conn->peerId = g_nextPeerId++;
+            if (CoopNet::AdminController_IsBanned(e.conn->peerId))
+            {
+                enet_peer_disconnect(evt.peer, 0);
+                delete e.conn;
+            }
+            else
+            {
+                g_Peers.push_back(e);
+                std::cout << "peer connected id=" << e.conn->peerId << std::endl;
+                Nat_PerformHandshake(e.conn);
+                e.conn->SendSectorChange(CoopNet::Fnv1a64("start_sector"));
+            }
             break;
         }
         case ENET_EVENT_TYPE_DISCONNECT:
         {
-            auto it = std::find_if(g_Peers.begin(), g_Peers.end(), [&](const PeerEntry& p){ return p.peer == evt.peer; });
+            auto it =
+                std::find_if(g_Peers.begin(), g_Peers.end(), [&](const PeerEntry& p) { return p.peer == evt.peer; });
             if (it != g_Peers.end())
             {
                 delete it->conn;
@@ -87,7 +112,8 @@ void Net_Poll(uint32_t maxMs)
         {
             if (evt.packet && evt.packet->dataLength >= sizeof(PacketHeader))
             {
-                auto it = std::find_if(g_Peers.begin(), g_Peers.end(), [&](const PeerEntry& p){ return p.peer == evt.peer; });
+                auto it = std::find_if(g_Peers.begin(), g_Peers.end(),
+                                       [&](const PeerEntry& p) { return p.peer == evt.peer; });
                 if (it != g_Peers.end())
                 {
                     Connection::RawPacket pkt;
@@ -108,4 +134,357 @@ void Net_Poll(uint32_t maxMs)
 bool Net_IsAuthoritative()
 {
     return CoopNet::kDedicatedAuthority;
+}
+
+std::vector<Connection*> Net_GetConnections()
+{
+    std::vector<Connection*> out;
+    out.reserve(g_Peers.size());
+    for (auto& e : g_Peers)
+        out.push_back(e.conn);
+    return out;
+}
+
+void Net_Send(Connection* conn, EMsg type, const void* data, uint16_t size)
+{
+    if (!g_Host || !conn)
+        return;
+
+    auto it = std::find_if(g_Peers.begin(), g_Peers.end(), [&](const PeerEntry& p) { return p.conn == conn; });
+    if (it == g_Peers.end())
+        return;
+
+    ENetPacket* pkt = enet_packet_create(nullptr, sizeof(PacketHeader) + size, ENET_PACKET_FLAG_RELIABLE);
+    PacketHeader hdr{static_cast<uint16_t>(type), size};
+    std::memcpy(pkt->data, &hdr, sizeof(hdr));
+    if (size > 0 && data)
+        std::memcpy(pkt->data + sizeof(hdr), data, size);
+    enet_peer_send(it->peer, 0, pkt);
+}
+
+void Net_Broadcast(EMsg type, const void* data, uint16_t size)
+{
+    if (!g_Host)
+        return;
+
+    ENetPacket* pkt = enet_packet_create(nullptr, sizeof(PacketHeader) + size, ENET_PACKET_FLAG_RELIABLE);
+    PacketHeader hdr{static_cast<uint16_t>(type), size};
+    std::memcpy(pkt->data, &hdr, sizeof(hdr));
+    if (size > 0 && data)
+        std::memcpy(pkt->data + sizeof(hdr), data, size);
+    enet_host_broadcast(g_Host, 0, pkt);
+}
+
+void Net_SendSectorReady(uint64_t hash)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        conns[0]->SendSectorReady(hash);
+    }
+}
+
+void Net_SendCraftRequest(uint32_t recipeId)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        CraftRequestPacket pkt{recipeId};
+        Net_Send(conns[0], EMsg::CraftRequest, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendAttachRequest(uint64_t itemId, uint8_t slotIdx, uint64_t attachmentId)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        AttachModRequestPacket pkt{itemId, slotIdx, {0, 0, 0}, attachmentId};
+        Net_Send(conns[0], EMsg::AttachModRequest, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendPurchaseRequest(uint32_t vendorId, uint32_t itemId, uint64_t nonce)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        PurchaseRequestPacket pkt{vendorId, itemId, nonce};
+        Net_Send(conns[0], EMsg::PurchaseRequest, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendBreachInput(uint8_t index)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        BreachInputPacket pkt{0u, index, {0, 0, 0}};
+        Net_Send(conns[0], EMsg::BreachInput, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendElevatorCall(uint32_t elevatorId, uint8_t floorIdx)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        ElevatorCallPacket pkt{0u, elevatorId, floorIdx, {0, 0, 0}};
+        Net_Send(conns[0], EMsg::ElevatorCall, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastVehicleExplode(uint32_t vehicleId, uint32_t vfxId, uint32_t seed)
+{
+    VehicleExplodePacket pkt{vehicleId, vfxId, seed};
+    Net_Broadcast(EMsg::VehicleExplode, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastPartDetach(uint32_t vehicleId, uint8_t partId)
+{
+    VehiclePartDetachPacket pkt{vehicleId, partId, {0, 0, 0}};
+    Net_Broadcast(EMsg::VehiclePartDetach, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastEject(uint32_t peerId, const RED4ext::Vector3& vel)
+{
+    EjectOccupantPacket pkt{peerId, vel};
+    Net_Broadcast(EMsg::EjectOccupant, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastVehicleSpawn(uint32_t vehicleId, uint32_t archetypeId, uint32_t paintId, const TransformSnap& t)
+{
+    VehicleSpawnPacket pkt{vehicleId, archetypeId, paintId, t};
+    Net_Broadcast(EMsg::VehicleSpawn, &pkt, sizeof(pkt));
+}
+
+void Net_SendSeatRequest(uint32_t vehicleId, uint8_t seatIdx)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        SeatRequestPacket pkt{vehicleId, seatIdx};
+        Net_Send(conns[0], EMsg::SeatRequest, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastSeatAssign(uint32_t peerId, uint32_t vehicleId, uint8_t seatIdx)
+{
+    SeatAssignPacket pkt{peerId, vehicleId, seatIdx};
+    Net_Broadcast(EMsg::SeatAssign, &pkt, sizeof(pkt));
+}
+
+void Net_SendVehicleHit(uint32_t vehicleId, uint16_t dmg, bool side)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        VehicleHitPacket pkt{vehicleId, dmg};
+        pkt.pad = side ? 1u : 0u;
+        Net_Send(conns[0], EMsg::VehicleHit, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastVehicleHit(uint32_t vehicleId, uint16_t dmg)
+{
+    VehicleHitPacket pkt{vehicleId, dmg};
+    Net_Broadcast(EMsg::VehicleHit, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastBreachStart(uint32_t peerId, uint32_t seed, uint8_t w, uint8_t h)
+{
+    BreachStartPacket pkt{peerId, seed, w, h, {0, 0}};
+    Net_Broadcast(EMsg::BreachStart, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastBreachInput(uint32_t peerId, uint8_t index)
+{
+    BreachInputPacket pkt{peerId, index, {0, 0, 0}};
+    Net_Broadcast(EMsg::BreachInput, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastBreachResult(uint32_t peerId, uint8_t mask)
+{
+    BreachResultPacket pkt{peerId, mask, {0, 0, 0}};
+    Net_Broadcast(EMsg::BreachResult, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastHeat(uint8_t level)
+{
+    HeatPacket pkt{level, {0, 0, 0}};
+    Net_Broadcast(EMsg::HeatSync, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastElevatorCall(uint32_t peerId, uint32_t elevatorId, uint8_t floorIdx)
+{
+    ElevatorCallPacket pkt{peerId, elevatorId, floorIdx, {0, 0, 0}};
+    Net_Broadcast(EMsg::ElevatorCall, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastElevatorArrive(uint32_t elevatorId, uint64_t sectorHash, const RED4ext::Vector3& pos)
+{
+    ElevatorArrivePacket pkt{elevatorId, sectorHash, pos};
+    Net_Broadcast(EMsg::ElevatorArrive, &pkt, sizeof(pkt));
+}
+
+void Net_SendTeleportAck(uint32_t elevatorId)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        TeleportAckPacket pkt{elevatorId};
+        Net_Send(conns[0], EMsg::TeleportAck, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastHoloCallStart(uint32_t peerId)
+{
+    HoloCallPacket pkt{peerId};
+    Net_Broadcast(EMsg::HoloCallStart, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastHoloCallEnd(uint32_t peerId)
+{
+    HoloCallPacket pkt{peerId};
+    Net_Broadcast(EMsg::HoloCallEnd, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastTickRateChange(uint16_t tickMs)
+{
+    TickRateChangePacket pkt{tickMs, 0};
+    Net_Broadcast(EMsg::TickRateChange, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastRuleChange(bool friendly)
+{
+    RuleChangePacket pkt{static_cast<uint8_t>(friendly), {0, 0, 0}};
+    Net_Broadcast(EMsg::RuleChange, &pkt, sizeof(pkt));
+}
+
+void Net_SendSpectateRequest(uint32_t peerId)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        SpectatePacket pkt{peerId};
+        Net_Send(conns[0], EMsg::SpectateRequest, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendSpectateGranted(uint32_t peerId)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        SpectatePacket pkt{peerId};
+        Net_Send(conns[0], EMsg::SpectateGranted, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastScoreUpdate(uint32_t peerId, uint16_t k, uint16_t d)
+{
+    ScoreUpdatePacket pkt{peerId, k, d};
+    Net_Broadcast(EMsg::ScoreUpdate, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastMatchOver(uint32_t winnerId)
+{
+    MatchOverPacket pkt{winnerId};
+    Net_Broadcast(EMsg::MatchOver, &pkt, sizeof(pkt));
+}
+
+void Net_SendAdminCmd(Connection* conn, uint8_t cmdType, uint64_t param)
+{
+    if (!conn)
+        return;
+    AdminCmdPacket pkt{cmdType, {0, 0, 0}, param};
+    Net_Send(conn, EMsg::AdminCmd, &pkt, sizeof(pkt));
+}
+
+void Net_Disconnect(Connection* conn)
+{
+    if (!g_Host || !conn)
+        return;
+    auto it = std::find_if(g_Peers.begin(), g_Peers.end(), [&](const PeerEntry& p) { return p.conn == conn; });
+    if (it != g_Peers.end())
+    {
+        enet_peer_disconnect(it->peer, 0);
+    }
+}
+
+void Net_BroadcastNatCandidate(const char* sdp)
+{
+    NatCandidatePacket pkt{};
+    std::strncpy(pkt.sdp, sdp, sizeof(pkt.sdp) - 1);
+    Net_Broadcast(EMsg::NatCandidate, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastCineStart(uint32_t sceneId, uint32_t startTimeMs)
+{
+    CineStartPacket pkt{sceneId, startTimeMs};
+    Net_Broadcast(EMsg::CineStart, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastViseme(uint32_t npcId, uint8_t visemeId, uint32_t timeMs)
+{
+    VisemePacket pkt{npcId, visemeId, {0, 0, 0}, timeMs};
+    Net_Broadcast(EMsg::Viseme, &pkt, sizeof(pkt));
+}
+
+void Net_SendDialogChoice(uint8_t choiceIdx)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        DialogChoicePacket pkt{0u, choiceIdx, {0, 0, 0}};
+        Net_Send(conns[0], EMsg::DialogChoice, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastDialogChoice(uint32_t peerId, uint8_t choiceIdx)
+{
+    DialogChoicePacket pkt{peerId, choiceIdx, {0, 0, 0}};
+    Net_Broadcast(EMsg::DialogChoice, &pkt, sizeof(pkt));
+}
+
+void Net_SendVoice(const uint8_t* data, uint16_t size, uint16_t seq)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        VoicePacket pkt{0u, seq, size, {0}};
+        std::memcpy(pkt.data, data, std::min<size_t>(size, sizeof(pkt.data)));
+        Net_Send(conns[0], EMsg::Voice, &pkt, static_cast<uint16_t>(sizeof(pkt)));
+    }
+}
+
+void Net_BroadcastVoice(uint32_t peerId, const uint8_t* data, uint16_t size, uint16_t seq)
+{
+    VoicePacket pkt{peerId, seq, size, {0}};
+    std::memcpy(pkt.data, data, std::min<size_t>(size, sizeof(pkt.data)));
+    Net_Broadcast(EMsg::Voice, &pkt, static_cast<uint16_t>(sizeof(pkt)));
+}
+
+void Net_BroadcastWorldState(uint64_t clockMs, uint32_t sunAngle, uint8_t weatherId, uint32_t weatherSeed,
+                             uint8_t bdPhase)
+{
+    WorldStatePacket pkt{clockMs, sunAngle, weatherSeed, weatherId, bdPhase, {0, 0}};
+    Net_Broadcast(EMsg::WorldState, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastGlobalEvent(uint32_t eventId, uint8_t phase, bool start, uint32_t seed)
+{
+    GlobalEventPacket pkt{eventId, seed, phase, static_cast<uint8_t>(start), {0, 0}};
+    Net_Broadcast(EMsg::GlobalEvent, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastCrowdSeed(uint64_t sectorHash, uint32_t seed)
+{
+    CrowdSeedPacket pkt{sectorHash, seed};
+    Net_Broadcast(EMsg::CrowdSeed, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastVendorStock(const VendorStockPacket& pkt)
+{
+    Net_Broadcast(EMsg::VendorStock, &pkt, sizeof(VendorStockPacket));
 }

--- a/cp2077-coop/src/net/Net.hpp
+++ b/cp2077-coop/src/net/Net.hpp
@@ -2,8 +2,65 @@
 
 // Networking layer for cp2077-coop.
 // Provides thin wrappers around ENet.
+#include "Packets.hpp"
+#include <RED4ext/Scripting/Natives/Generated/Vector3.hpp>
 #include <cstdint>
+#include <vector>
+
+namespace CoopNet
+{
+class Connection;
+}
 void Net_Init();
 void Net_Shutdown();
 void Net_Poll(uint32_t maxMs);
 bool Net_IsAuthoritative();
+std::vector<CoopNet::Connection*> Net_GetConnections();
+void Net_Send(CoopNet::Connection* conn, CoopNet::EMsg type, const void* data, uint16_t size);
+void Net_Broadcast(CoopNet::EMsg type, const void* data, uint16_t size);
+void Net_SendSectorReady(uint64_t hash);
+void Net_SendCraftRequest(uint32_t recipeId);
+void Net_SendAttachRequest(uint64_t itemId, uint8_t slotIdx, uint64_t attachmentId);
+void Net_SendBreachInput(uint8_t index);
+void Net_BroadcastVehicleExplode(uint32_t vehicleId, uint32_t vfxId, uint32_t seed);
+void Net_BroadcastPartDetach(uint32_t vehicleId, uint8_t partId);
+void Net_BroadcastEject(uint32_t peerId, const RED4ext::Vector3& vel);
+void Net_BroadcastVehicleSpawn(uint32_t vehicleId, uint32_t archetypeId, uint32_t paintId, const TransformSnap& t);
+void Net_SendSeatRequest(uint32_t vehicleId, uint8_t seatIdx);
+void Net_BroadcastSeatAssign(uint32_t peerId, uint32_t vehicleId, uint8_t seatIdx);
+void Net_SendVehicleHit(uint32_t vehicleId, uint16_t dmg, bool side);
+void Net_BroadcastVehicleHit(uint32_t vehicleId, uint16_t dmg);
+void Net_BroadcastBreachStart(uint32_t peerId, uint32_t seed, uint8_t w, uint8_t h);
+void Net_BroadcastBreachInput(uint32_t peerId, uint8_t index);
+void Net_BroadcastBreachResult(uint32_t peerId, uint8_t mask);
+void Net_BroadcastHeat(uint8_t level);
+void Net_BroadcastElevatorCall(uint32_t peerId, uint32_t elevatorId, uint8_t floorIdx);
+void Net_SendElevatorCall(uint32_t elevatorId, uint8_t floorIdx);
+void Net_BroadcastElevatorArrive(uint32_t elevatorId, uint64_t sectorHash, const RED4ext::Vector3& pos);
+void Net_SendTeleportAck(uint32_t elevatorId);
+void Net_BroadcastHoloCallStart(uint32_t peerId);
+void Net_BroadcastHoloCallEnd(uint32_t peerId);
+void Net_BroadcastTickRateChange(uint16_t tickMs);
+void Net_BroadcastRuleChange(bool friendly);
+void Net_SendSpectateRequest(uint32_t peerId);
+void Net_SendSpectateGranted(uint32_t peerId);
+void Net_SendAdminCmd(CoopNet::Connection* conn, uint8_t cmdType, uint64_t param);
+void Net_BroadcastScoreUpdate(uint32_t peerId, uint16_t k, uint16_t d);
+void Net_BroadcastMatchOver(uint32_t winnerId);
+void Net_Disconnect(CoopNet::Connection* conn);
+void Nat_Start();
+void Nat_PerformHandshake(CoopNet::Connection* conn);
+uint64_t Nat_GetRelayBytes();
+void Net_BroadcastNatCandidate(const char* sdp);
+void Net_BroadcastCineStart(uint32_t sceneId, uint32_t startTimeMs);
+void Net_BroadcastViseme(uint32_t npcId, uint8_t visemeId, uint32_t timeMs);
+void Net_SendDialogChoice(uint8_t choiceIdx);
+void Net_BroadcastDialogChoice(uint32_t peerId, uint8_t choiceIdx);
+void Net_SendVoice(const uint8_t* data, uint16_t size, uint16_t seq);
+void Net_BroadcastVoice(uint32_t peerId, const uint8_t* data, uint16_t size, uint16_t seq);
+void Net_BroadcastWorldState(uint64_t clockMs, uint32_t sunAngle, uint8_t weatherId, uint32_t weatherSeed,
+                             uint8_t bdPhase);
+void Net_BroadcastGlobalEvent(uint32_t eventId, uint8_t phase, bool start, uint32_t seed);
+void Net_BroadcastCrowdSeed(uint64_t sectorHash, uint32_t seed);
+void Net_BroadcastVendorStock(const VendorStockPacket& pkt);
+void Net_SendPurchaseRequest(uint32_t vendorId, uint32_t itemId, uint64_t nonce);

--- a/cp2077-coop/src/net/Packets.hpp
+++ b/cp2077-coop/src/net/Packets.hpp
@@ -2,8 +2,8 @@
 // Example header JSON: {"type":1,"size":42}
 #pragma once
 
-#include <cstdint>
 #include "Snapshot.hpp"
+#include <cstdint>
 
 namespace CoopNet
 {
@@ -30,21 +30,68 @@ enum class EMsg : uint16_t
     HitRequest,
     HitConfirm,
     VehicleSpawn,
+    SeatRequest,
     SeatAssign,
     VehicleHit,
     Quickhack,
     HeatSync,
     WorldState,
     ScoreUpdate,
+    MatchOver,
     NpcSnapshot,
     NpcSpawn,
-    NpcDespawn
+    NpcDespawn,
+    SectorChange,
+    SectorReady,
+    ItemSnap,
+    CraftRequest,
+    CraftResult,
+    AttachModRequest,
+    AttachModResult,
+    VehicleExplode,
+    VehiclePartDetach,
+    EjectOccupant,
+    InterestAdd,
+    InterestRemove,
+    TickRateChange,
+    BreachStart,
+    BreachInput,
+    BreachResult,
+    ElevatorCall,
+    ElevatorArrive,
+    TeleportAck,
+    HoloCallStart,
+    HoloCallEnd,
+    RuleChange,
+    AdminCmd,
+    SpectateRequest,
+    SpectateGranted,
+    NatCandidate,
+    CineStart,
+    Viseme,
+    DialogChoice,
+    Voice,
+    GlobalEvent,
+    CrowdSeed,
+    VendorStock,
+    PurchaseRequest,
+    PurchaseResult
 };
 
 struct PacketHeader
 {
     uint16_t type;
     uint16_t size;
+};
+
+struct PingPacket
+{
+    uint32_t timeMs;
+};
+
+struct PongPacket
+{
+    uint32_t timeMs;
 };
 
 constexpr size_t kHeaderSize = sizeof(PacketHeader);
@@ -90,7 +137,15 @@ struct VersionPacket
 struct VehicleSpawnPacket
 {
     uint32_t vehicleId;
+    uint32_t archetypeId;
+    uint32_t paintId;
     TransformSnap transform;
+};
+
+struct SeatRequestPacket
+{
+    uint32_t vehicleId;
+    uint8_t seatIdx; // 0-3
 };
 
 struct SeatAssignPacket
@@ -104,12 +159,18 @@ struct VehicleHitPacket
 {
     uint32_t vehicleId;
     uint16_t dmg;
+    uint8_t side; // 1 if side impact
+    uint8_t pad;
 };
 
 struct WorldStatePacket
 {
+    uint64_t worldClockMs;
     uint32_t sunAngle; // degrees * 100
+    uint32_t weatherSeed;
     uint8_t weatherId;
+    uint8_t braindancePhase;
+    uint8_t pad[2];
 };
 
 struct ScoreUpdatePacket
@@ -117,6 +178,11 @@ struct ScoreUpdatePacket
     uint32_t peerId;
     uint16_t k;
     uint16_t d;
+};
+
+struct MatchOverPacket
+{
+    uint32_t winnerId;
 };
 
 struct NpcSnapshotPacket
@@ -134,5 +200,245 @@ struct NpcDespawnPacket
     uint32_t npcId;
 };
 
-} // namespace CoopNet
+struct SectorChangePacket
+{
+    uint32_t peerId;
+    uint64_t sectorHash;
+};
 
+struct SectorReadyPacket
+{
+    uint64_t sectorHash;
+};
+
+struct ItemSnapPacket
+{
+    ItemSnap snap;
+};
+
+struct CraftRequestPacket
+{
+    uint32_t recipeId;
+};
+
+struct CraftResultPacket
+{
+    ItemSnap item;
+};
+
+struct AttachModRequestPacket
+{
+    uint64_t itemId;
+    uint8_t slotIdx;
+    uint8_t _pad[3];
+    uint64_t attachmentId;
+};
+
+struct AttachModResultPacket
+{
+    ItemSnap item;
+    uint8_t success;
+    uint8_t _pad2[3];
+};
+
+struct HeatPacket
+{
+    uint8_t level;
+    uint8_t _pad[3];
+};
+
+struct VehicleExplodePacket
+{
+    uint32_t vehicleId;
+    uint32_t vfxId;
+    uint32_t seed;
+};
+
+struct VehiclePartDetachPacket
+{
+    uint32_t vehicleId;
+    uint8_t partId; // 0=door_L,1=door_R,2=hood,3=trunk
+    uint8_t _pad[3];
+};
+
+struct EjectOccupantPacket
+{
+    uint32_t peerId;
+    RED4ext::Vector3 velocity;
+};
+
+struct InterestPacket
+{
+    uint32_t id;
+};
+
+struct TickRateChangePacket
+{
+    uint16_t tickMs;
+    uint16_t _pad;
+};
+
+struct BreachStartPacket
+{
+    uint32_t peerId;
+    uint32_t seed;
+    uint8_t gridW;
+    uint8_t gridH;
+    uint8_t _pad[2];
+};
+
+struct BreachInputPacket
+{
+    uint32_t peerId;
+    uint8_t index;
+    uint8_t _pad[3];
+};
+
+struct BreachResultPacket
+{
+    uint32_t peerId;
+    uint8_t daemonsMask;
+    uint8_t _pad[3];
+};
+
+struct ElevatorCallPacket
+{
+    uint32_t peerId;
+    uint32_t elevatorId;
+    uint8_t floorIdx;
+    uint8_t _pad[3];
+};
+
+struct ElevatorArrivePacket
+{
+    uint32_t elevatorId;
+    uint64_t sectorHash;
+    RED4ext::Vector3 pos;
+};
+
+// Acknowledges elevator arrival per-connection; peer is inferred from ENet peer.
+struct TeleportAckPacket
+{
+    uint32_t elevatorId;
+};
+
+struct RuleChangePacket
+{
+    uint8_t friendlyFire;
+    uint8_t _pad[3];
+};
+
+struct HoloCallPacket
+{
+    uint32_t peerId;
+};
+
+struct AdminCmdPacket
+{
+    uint8_t cmdType; // 0=Kick,1=Ban,2=Mute
+    uint8_t _pad[3];
+    uint64_t param;
+};
+
+struct SpectatePacket
+{
+    uint32_t peerId;
+};
+
+struct NatCandidatePacket
+{
+    char sdp[256];
+};
+
+struct CineStartPacket
+{
+    uint32_t sceneId;
+    uint32_t startTimeMs;
+};
+
+struct VisemePacket
+{
+    uint32_t npcId;
+    uint8_t visemeId; // AA, TH, FV, etc.
+    uint8_t _pad[3];
+    uint32_t timeMs;
+};
+
+struct DialogChoicePacket
+{
+    uint32_t peerId;
+    uint8_t choiceIdx;
+    uint8_t _pad[3];
+};
+
+struct VoicePacket
+{
+    uint32_t peerId;
+    uint16_t seq;
+    uint16_t size;
+    uint8_t data[256];
+};
+
+struct GlobalEventPacket
+{
+    uint32_t eventId;
+    uint32_t seed;
+    uint8_t phase;
+    uint8_t start; // 1=start, 0=stop
+    uint8_t pad[2];
+};
+
+struct CrowdSeedPacket
+{
+    uint64_t sectorHash;
+    uint32_t seed;
+};
+
+struct VendorStockItem
+{
+    uint32_t itemId;
+    uint32_t price;
+};
+
+struct VendorStockPacket
+{
+    uint32_t vendorId;
+    uint8_t count;
+    uint8_t _pad[3];
+    VendorStockItem items[8];
+};
+
+struct PurchaseRequestPacket
+{
+    uint32_t vendorId;
+    uint32_t itemId;
+    uint64_t nonce;
+};
+
+struct PurchaseResultPacket
+{
+    uint32_t vendorId;
+    uint32_t itemId;
+    uint64_t balance;
+    uint8_t success;
+    uint8_t _pad[3];
+};
+
+struct AvatarSpawnPacket
+{
+    uint32_t peerId;
+    TransformSnap snap;
+};
+
+struct AvatarDespawnPacket
+{
+    uint32_t peerId;
+};
+
+struct ChatPacket
+{
+    uint32_t peerId;
+    char msg[64];
+};
+
+} // namespace CoopNet

--- a/cp2077-coop/src/net/StatBatch.cpp
+++ b/cp2077-coop/src/net/StatBatch.cpp
@@ -1,27 +1,56 @@
 #include "StatBatch.hpp"
+#include "Net.hpp"
+#include "../../third_party/httplib.h"
 #include <iostream>
+#include <sstream>
 
-// Batches score updates to reduce bandwidth. Sent once per tick.
+// Batches player stats and posts to master server every 30 s.
 namespace CoopNet
 {
 static BatchedStats g_stats;
+static float g_timer = 0.f;
 
-void FlushStats()
+static void FlushStats()
 {
     if (g_stats.peerId.empty())
         return;
-    // TODO(next ticket): serialize and send ScoreUpdate packet.
-    g_stats.peerId.clear();
-    g_stats.k.clear();
-    g_stats.d.clear();
-    std::cout << "FlushStats" << std::endl;
+    std::stringstream ss;
+    ss << "{\"rows\":[";
+    for (size_t i = 0; i < g_stats.peerId.size(); ++i)
+    {
+        Net_BroadcastScoreUpdate(g_stats.peerId[i], g_stats.k[i], g_stats.d[i]);
+        if (i > 0) ss << ',';
+        ss << "{\"id\":" << g_stats.peerId[i]
+           << ",\"k\":" << g_stats.k[i]
+           << ",\"d\":" << g_stats.d[i]
+           << ",\"a\":" << g_stats.a[i]
+           << ",\"dmg\":" << g_stats.dmg[i]
+           << ",\"hs\":" << g_stats.hs[i] << '}';
+    }
+    ss << "]}";
+    httplib::SSLClient cli("coop-master", 443);
+    cli.Post("/api/stats", ss.str(), "application/json");
+    g_stats = BatchedStats();
 }
 
-void AddScore(uint32_t peerId, uint16_t k, uint16_t d)
+void StatBatch_Tick(float dt)
+{
+    g_timer += dt;
+    if (g_timer >= 30.f)
+    {
+        g_timer = 0.f;
+        FlushStats();
+    }
+}
+
+void AddStats(uint32_t peerId, uint16_t k, uint16_t d, uint16_t a, uint32_t dmg, uint16_t hs)
 {
     g_stats.peerId.push_back(peerId);
     g_stats.k.push_back(k);
     g_stats.d.push_back(d);
+    g_stats.a.push_back(a);
+    g_stats.dmg.push_back(dmg);
+    g_stats.hs.push_back(hs);
 }
 
 } // namespace CoopNet

--- a/cp2077-coop/src/net/StatBatch.hpp
+++ b/cp2077-coop/src/net/StatBatch.hpp
@@ -11,9 +11,12 @@ struct BatchedStats
     std::vector<uint32_t> peerId;
     std::vector<uint16_t> k;
     std::vector<uint16_t> d;
+    std::vector<uint16_t> a;
+    std::vector<uint32_t> dmg;
+    std::vector<uint16_t> hs;
 };
 
-void FlushStats();
-void AddScore(uint32_t peerId, uint16_t k, uint16_t d);
+void StatBatch_Tick(float dt);
+void AddStats(uint32_t peerId, uint16_t k, uint16_t d, uint16_t a, uint32_t dmg, uint16_t hs);
 
 } // namespace CoopNet

--- a/cp2077-coop/src/physics/CarPhysics.cpp
+++ b/cp2077-coop/src/physics/CarPhysics.cpp
@@ -1,21 +1,49 @@
 #include "CarPhysics.hpp"
+#include "../core/GameClock.hpp"
+#include <cmath>
 
 namespace CoopNet
 {
-// Fixed-step Euler integration placeholder for vehicles.
+// Fixed-step Euler integration for vehicles.
 // When both server and client use the same dtMs the drift in position
 // should stay under a few centimeters after long runs. Any mismatch in
 // the step size will accumulate error over time.
 void ServerSimulate(TransformSnap& snap, float dtMs)
 {
     float dt = dtMs / 1000.f;
+    uint64_t frame = GameClock::GetCurrentTick();
+    float noise = std::sinf(static_cast<float>(frame) * 0.1f) * 0.01f;
+    // Integrate linear velocity
     snap.pos += snap.vel * dt;
-    // TODO(next ticket): integrate rotation and forces
+    // Simple friction with deterministic noise
+    snap.vel.X = (snap.vel.X + noise) * 0.98f;
+    snap.vel.Y = (snap.vel.Y - noise) * 0.98f;
+    // Rotate to face velocity direction if moving
+    float speed2 = snap.vel.X * snap.vel.X + snap.vel.Y * snap.vel.Y;
+    if (speed2 > 0.0001f)
+    {
+        float yaw = std::atan2f(snap.vel.Y, snap.vel.X);
+        float s = std::sinf(yaw * 0.5f);
+        float c = std::cosf(yaw * 0.5f);
+        snap.rot = {0.f, 0.f, s, c};
+    }
 }
 
 void ClientPredict(TransformSnap& snap, float dtMs)
 {
     float dt = dtMs / 1000.f;
+    uint64_t frame = GameClock::GetCurrentTick();
+    float noise = std::sinf(static_cast<float>(frame) * 0.1f) * 0.01f;
     snap.pos += snap.vel * dt;
+    snap.vel.X = (snap.vel.X + noise) * 0.98f;
+    snap.vel.Y = (snap.vel.Y - noise) * 0.98f;
+    float speed2 = snap.vel.X * snap.vel.X + snap.vel.Y * snap.vel.Y;
+    if (speed2 > 0.0001f)
+    {
+        float yaw = std::atan2f(snap.vel.Y, snap.vel.X);
+        float s = std::sinf(yaw * 0.5f);
+        float c = std::cosf(yaw * 0.5f);
+        snap.rot = {0.f, 0.f, s, c};
+    }
 }
 } // namespace CoopNet

--- a/cp2077-coop/src/physics/CarPhysics.hpp
+++ b/cp2077-coop/src/physics/CarPhysics.hpp
@@ -4,6 +4,7 @@
 
 namespace CoopNet
 {
+constexpr float kVehicleStepMs = 16.f; // 60 Hz
 // Server authoritative car physics integration.
 void ServerSimulate(TransformSnap& inout, float dtMs);
 

--- a/cp2077-coop/src/runtime/CutsceneSync.reds
+++ b/cp2077-coop/src/runtime/CutsceneSync.reds
@@ -1,0 +1,79 @@
+public class CutsceneSync {
+  private struct VisemeEvent {
+    var npcId: Uint32;
+    var visemeId: Uint8;
+    var timeMs: Uint32;
+  }
+
+  private static let queuedVisemes: array<VisemeEvent>;
+
+  public static func OnCineStart(sceneId: Uint32, startTimeMs: Uint32) -> Void {
+    LogChannel(n"DEBUG", "CineStart " + IntToString(Cast<Int32>(sceneId)));
+    if !Net_IsAuthoritative() {
+      let camSys = GameInstance.GetCameraSystem(GetGame());
+      camSys.Seek(sceneId, startTimeMs);
+    };
+  }
+
+  public static func OnViseme(npcId: Uint32, visemeId: Uint8, timeMs: Uint32) -> Void {
+    LogChannel(n"DEBUG", "Viseme " + IntToString(Cast<Int32>(visemeId)));
+    if Net_IsAuthoritative() {
+      Net_BroadcastViseme(npcId, visemeId, timeMs);
+    } else {
+      let ev: VisemeEvent;
+      ev.npcId = npcId;
+      ev.visemeId = visemeId;
+      ev.timeMs = timeMs;
+      ArrayPush(queuedVisemes, ev);
+    };
+  }
+
+  public static func OnDialogChoice(peerId: Uint32, idx: Uint8) -> Void {
+    LogChannel(n"DEBUG", "DialogChoice " + IntToString(Cast<Int32>(idx)));
+    if !Net_IsAuthoritative() {
+      Net_SendDialogChoice(idx);
+    } else {
+      if ApplyDialogChoice(idx) {
+        Net_BroadcastDialogChoice(peerId, idx);
+      };
+    };
+  }
+
+  public static func FetchVisemeEvents(out events: array<VisemeEvent>) -> Void {
+    events = queuedVisemes;
+    queuedVisemes.Clear();
+  }
+}
+
+public static func ApplyDialogChoice(idx: Uint8) -> Bool {
+  let conv = GameInstance.GetConversationStateMachine(GetGame());
+  if !IsDefined(conv) {
+    return false;
+  };
+  if conv.IsChoiceValid(idx) {
+    conv.AdvanceChoice(idx);
+    return true;
+  };
+  return false;
+}
+
+public static func CutsceneSync_CineStart(sceneId: Uint32, startMs: Uint32) -> Void {
+  CutsceneSync.OnCineStart(sceneId, startMs);
+}
+
+public static func CutsceneSync_Viseme(npcId: Uint32, visemeId: Uint8, timeMs: Uint32) -> Void {
+  CutsceneSync.OnViseme(npcId, visemeId, timeMs);
+}
+
+public static func CutsceneSync_DialogChoice(peerId: Uint32, idx: Uint8) -> Void {
+  CutsceneSync.OnDialogChoice(peerId, idx);
+}
+
+@hook(gamevision.StartCinematic)
+protected func gamevision_StartCinematic(original: func(ref<gamevision>, Uint32, Uint32), self: ref<gamevision>, sceneId: Uint32, startMs: Uint32) -> Void {
+  original(self, sceneId, startMs);
+  CutsceneSync.OnCineStart(sceneId, startMs);
+  if Net_IsAuthoritative() {
+    Net_BroadcastCineStart(sceneId, startMs);
+  };
+}

--- a/cp2077-coop/src/runtime/ElevatorSync.reds
+++ b/cp2077-coop/src/runtime/ElevatorSync.reds
@@ -1,0 +1,52 @@
+public class ElevatorSync {
+    private static var pendingSector: Uint64;
+    private static var pendingPos: Vector3;
+    private static var pendingElevator: Uint32;
+
+    public static func OnElevatorCall(id: Uint32, floor: Uint8) -> Void {
+        Net_SendElevatorCall(id, floor);
+    }
+
+    public static func OnElevatorArrive(id: Uint32, sector: Uint64, pos: Vector3) -> Void {
+        let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject() as AvatarProxy;
+        if IsDefined(player) { player.currentSector = sector; };
+        pendingSector = sector;
+        pendingPos = pos;
+        pendingElevator = id;
+        LogChannel(n"DEBUG", "Elevator arrive " + IntToString(id));
+    }
+
+    public static func OnStreamingDone(hash: Uint64) -> Void {
+        if pendingSector == hash {
+            let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject() as AvatarProxy;
+            if IsDefined(player) {
+                player.pos = pendingPos;
+            };
+            Net_SendTeleportAck(pendingElevator);
+            pendingSector = 0uL;
+        }
+    }
+}
+
+public static func ElevatorSync_OnArrive(id: Uint32, sector: Uint64, pos: Vector3) -> Void {
+    ElevatorSync.OnElevatorArrive(id, sector, pos);
+}
+
+@hook(workElevator.UseFloorButton)
+protected func workElevator_UseFloorButton(original: func(ref<workElevator>, Int32), self: ref<workElevator>, floor: Int32) -> Void {
+    original(self, floor);
+    let name = self.GetClassName();
+    let hash = ElevatorSync.Hash32(NameToString(name));
+    ElevatorSync.OnElevatorCall(hash, Cast<Uint8>(floor));
+}
+
+private static func Hash32(s: String) -> Uint32 {
+    var h: Uint32 = 2166136261u;
+    var i: Int32 = 0;
+    while i < StrLen(s) {
+        h = h ^ Cast<Uint8>(s[i]);
+        h = h * 16777619u;
+        i += 1;
+    };
+    return h;
+}

--- a/cp2077-coop/src/runtime/GlobalEventManager.reds
+++ b/cp2077-coop/src/runtime/GlobalEventManager.reds
@@ -1,0 +1,5 @@
+public class GlobalEventManager {
+    public static func OnEvent(eventId: Uint32, phase: Uint8, seed: Uint32, start: Bool) -> Void {
+        LogChannel(n"DEBUG", "Event " + IntToString(eventId) + " phase=" + IntToString(phase) + (start ? " start" : " stop"));
+    }
+}

--- a/cp2077-coop/src/runtime/HeatSync.reds
+++ b/cp2077-coop/src/runtime/HeatSync.reds
@@ -1,15 +1,27 @@
 // Shares NCPD heat level among peers.
 public class HeatSync {
     public static let heatLevel: Uint8 = 0;
+    public static let armorScale: Float = 1.0;
+    public static let damageScale: Float = 1.0;
 
     public static func BroadcastHeat(level: Uint8) -> Void {
         heatLevel = level;
-        // NetCore.BroadcastHeat(level);
+        Net_BroadcastHeat(level);
         LogChannel(n"DEBUG", "BroadcastHeat " + IntToString(level));
     }
 
     public static func ApplyHeat(level: Uint8) -> Void {
         heatLevel = level;
         LogChannel(n"DEBUG", "ApplyHeat " + IntToString(level));
+    }
+
+    public static func ApplyArmorDebuff(scale: Float) -> Void {
+        armorScale = scale;
+        LogChannel(n"DEBUG", "ApplyArmorDebuff scale=" + FloatToString(scale));
+    }
+
+    public static func ApplyDamageBuff(scale: Float) -> Void {
+        damageScale = scale;
+        LogChannel(n"DEBUG", "ApplyDamageBuff scale=" + FloatToString(scale));
     }
 }

--- a/cp2077-coop/src/runtime/Inventory.reds
+++ b/cp2077-coop/src/runtime/Inventory.reds
@@ -1,0 +1,63 @@
+// Temporary runtime table; persistent storage handled in a later ticket.
+public struct ItemSnap {
+    public var itemId: Uint64;
+    public var ownerId: Uint32;
+    public var tpl: Uint16;
+    public var level: Uint16;
+    public var quality: Uint16;
+    public var rolls: array<Uint32>;
+    public var slotMask: Uint8;
+    public var attachmentIds: array<Uint64>;
+}
+
+public class Inventory {
+    public static var items: array<ItemSnap>;
+
+    public static func OnItemSnap(snap: ref<ItemSnap>) -> Void {
+        let count: Int32 = ArraySize(items);
+        var i: Int32 = 0;
+        while i < count {
+            if items[i].itemId == snap.itemId {
+                items[i] = *snap;
+                return;
+            };
+            i += 1;
+        };
+        items.PushBack(*snap);
+        LogChannel(n"DEBUG", "OnItemSnap " + Uint64ToString(snap.itemId));
+    }
+
+    public static func OnCraftResult(snap: ref<ItemSnap>) -> Void {
+        items.PushBack(*snap);
+        LogChannel(n"DEBUG", "Crafted item " + Uint64ToString(snap.itemId));
+    }
+
+    public static func OnAttachResult(success: Bool, snap: ref<ItemSnap>) -> Void {
+        if success {
+            LogChannel(n"DEBUG", "Mod attached " + Uint64ToString(snap.itemId));
+        } else {
+            LogChannel(n"DEBUG", "Attach failed " + Uint64ToString(snap.itemId));
+        };
+    }
+
+    public static func OnPurchaseResult(itemId: Uint64, balance: Uint64, success: Bool) -> Void {
+        if success {
+            LogChannel(n"DEBUG", "Purchased item " + Uint64ToString(itemId));
+        } else {
+            LogChannel(n"DEBUG", "Purchase failed " + Uint64ToString(itemId));
+        };
+        // FIXME(next ticket): update wallet UI
+    }
+
+    public static func RequestCraft(recipeId: Uint32) -> Void {
+        Net_SendCraftRequest(recipeId);
+    }
+
+    public static func RequestAttach(itemId: Uint64, slotIdx: Uint8, attachId: Uint64) -> Void {
+        Net_SendAttachRequest(itemId, slotIdx, attachId);
+    }
+
+    public static func RequestPurchase(vendorId: Uint32, itemId: Uint32, nonce: Uint64) -> Void {
+        Net_SendPurchaseRequest(vendorId, itemId, nonce);
+    }
+}

--- a/cp2077-coop/src/runtime/NpcController.reds
+++ b/cp2077-coop/src/runtime/NpcController.reds
@@ -1,11 +1,61 @@
 // Server-authoritative NPC controller.
+public enum NpcState {
+    Idle,
+    Wander,
+    Combat
+}
+
 public class NpcController {
+    public static let proxies: array<ref<NpcProxy>>;
+    public static let crowdSeeds: ref<inkHashMap> = new inkHashMap();
+
     public static func ServerTick(dt: Float) -> Void {
-        // Random walk placeholder driven by deterministic RNG.
-        LogChannel(n"DEBUG", "NpcController.ServerTick dt=" + FloatToString(dt));
+        CoopNet.NpcController_ServerTick(dt);
+    }
+
+    private static func FindProxy(id: Uint32) -> ref<NpcProxy> {
+        for p in proxies {
+            if p.npcId == id { return p; };
+        };
+        return null;
     }
 
     public static func ClientApplySnap(snap: ref<NpcSnap>) -> Void {
-        LogChannel(n"DEBUG", "ApplyNpcSnap id=" + IntToString(snap.npcId));
+        let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject();
+        let dist = VectorDistance(player.GetWorldPosition(), snap.pos);
+        if dist > 120.0 {
+            let existing = FindProxy(snap.npcId);
+            if IsDefined(existing) {
+                existing.Despawn();
+                proxies.Erase(existing);
+            };
+            return;
+        };
+
+        let npc = FindProxy(snap.npcId);
+        if !IsDefined(npc) {
+            npc = new NpcProxy();
+            npc.Spawn(snap);
+            proxies.PushBack(npc);
+        } else {
+            npc.ApplySnap(snap);
+        };
+    }
+
+    public static func DespawnNpc(id: Uint32) -> Void {
+        let npc = FindProxy(id);
+        if IsDefined(npc) {
+            npc.Despawn();
+            proxies.Erase(npc);
+        };
+    }
+
+    public static func ApplyCrowdSeed(hash: Uint64, seed: Uint32) -> Void {
+        crowdSeeds.Insert(hash, seed);
+    }
+
+    public static func GetCrowdSeed(hash: Uint64) -> Uint32 {
+        let val = crowdSeeds.Get(hash) as Uint32;
+        return val;
     }
 }

--- a/cp2077-coop/src/runtime/NpcProxy.reds
+++ b/cp2077-coop/src/runtime/NpcProxy.reds
@@ -1,0 +1,67 @@
+public class NpcProxy extends gameObject {
+    public var npcId: Uint32;
+    public var templateId: Uint16;
+    public var pos: Vector3;
+    public var rot: Quaternion;
+    public var state: NpcState;
+    public var health: Uint16;
+    public var appearanceSeed: Uint8;
+    public var sectorHash: Uint64;
+
+    public func Spawn(snap: ref<NpcSnap>) -> Void {
+        npcId = snap.npcId;
+        templateId = snap.templateId;
+        appearanceSeed = snap.appearanceSeed;
+        sectorHash = snap.sectorHash;
+        pos = snap.pos;
+        rot = snap.rot;
+        state = snap.state;
+        health = snap.health;
+        LogChannel(n"DEBUG", "NpcProxy.Spawn " + IntToString(npcId) + " tpl=" + IntToString(templateId));
+        // Placeholder mesh spawn
+        LogChannel(n"DEBUG", "Spawn mesh base\\characters\\crowd_man_01.mesh");
+    }
+
+    public func ApplySnap(snap: ref<NpcSnap>) -> Void {
+        pos = snap.pos;
+        rot = snap.rot;
+        state = snap.state;
+        health = snap.health;
+        sectorHash = snap.sectorHash;
+        switch state {
+           case NpcState.Idle:
+                let seed = NpcController.GetCrowdSeed(sectorHash);
+                let tick = RoundF(GameInstance.GetSimTime() as Float);
+                let val = CoopNet.Fnv1a32(IntToString(npcId + tick)) ^ seed;
+                if val % 2u == 0u {
+                    SetAnimation(n"idle_wave");
+                } else {
+                    SetAnimation(n"idle");
+                };
+                break;
+           case NpcState.Wander:
+                let seed = NpcController.GetCrowdSeed(sectorHash);
+                let tick = RoundF(GameInstance.GetSimTime() as Float);
+                let val = CoopNet.Fnv1a32(IntToString(npcId + tick)) ^ seed;
+                if val % 2u == 0u {
+                    SetAnimation(n"walk_phone");
+                } else {
+                    SetAnimation(n"walk");
+                };
+                break;
+            case NpcState.Combat:
+                SetAnimation(n"combat");
+                break;
+        };
+        LogChannel(n"DEBUG", "NpcProxy.ApplySnap " + IntToString(npcId));
+    }
+
+    public func Despawn() -> Void {
+        LogChannel(n"DEBUG", "NpcProxy.Despawn " + IntToString(npcId));
+    }
+
+    private func SetAnimation(name: CName) -> Void {
+        // Would call animation controller when available
+        LogChannel(n"DEBUG", "Play anim " + NameToString(name));
+    }
+}

--- a/cp2077-coop/src/runtime/QuestSync.reds
+++ b/cp2077-coop/src/runtime/QuestSync.reds
@@ -3,9 +3,11 @@
 // subsequent objectives may never trigger for that player.
 // These helpers send stage and scene updates between peers.
 public class QuestSync {
+    public static var freezeQuests: Bool = false;
     // Called after the game advances a quest stage on the server.
     // Sends a network update so all clients stay in sync.
     public static func OnAdvanceStage(questName: CName) -> Void {
+        if freezeQuests { return; };
         LogChannel(n"DEBUG", "[QuestSync] " + NameToString(questName) + " stage advanced");
         SendQuestStageMsg(questName);
     }
@@ -37,6 +39,11 @@ public class QuestSync {
 
     public static func ApplySceneTrigger(id: TweakDBID, isStart: Bool) -> Void {
         LogChannel(n"DEBUG", "Apply SceneTrigger " + TDBID.ToStringDEBUG(id) + " start=" + BoolToString(isStart));
+    }
+
+    public static func SetFreeze(f: Bool) -> Void {
+        freezeQuests = f;
+        LogChannel(n"DEBUG", "freezeQuests=" + BoolToString(f));
     }
 }
 

--- a/cp2077-coop/src/runtime/QuickhackSync.reds
+++ b/cp2077-coop/src/runtime/QuickhackSync.reds
@@ -9,6 +9,9 @@ public struct HackInfo {
 public class QuickhackSync {
     public static var activeHacks: array<HackInfo>;
     private static var tickAccum: Uint32;
+    private static var armourTimer: Float;
+    private static var cameraTimer: Float;
+    private static var vulnTimer: Float;
     public static func SendHack(info: ref<HackInfo>) -> Void {
         // NetCore.BroadcastQuickhack(info);
         LogChannel(n"DEBUG", "SendHack target=" + IntToString(info.targetId));
@@ -33,6 +36,27 @@ public class QuickhackSync {
         }
         tickAccum -= 500u;
 
+        if armourTimer > 0.0 {
+            armourTimer -= 0.5;
+            if armourTimer <= 0.0 {
+                HeatSync.ApplyArmorDebuff(1.0);
+                LogChannel(n"DEBUG", "Daemon armour debuff expired");
+            }
+        };
+        if cameraTimer > 0.0 {
+            cameraTimer -= 0.5;
+            if cameraTimer <= 0.0 {
+                LogChannel(n"DEBUG", "Daemon camera disable ended");
+            }
+        };
+        if vulnTimer > 0.0 {
+            vulnTimer -= 0.5;
+            if vulnTimer <= 0.0 {
+                HeatSync.ApplyDamageBuff(1.0);
+                LogChannel(n"DEBUG", "Daemon mass vulnerability ended");
+            }
+        };
+
         var i: Int32 = 0;
         while i < activeHacks.Size() {
             let hack = activeHacks[i];
@@ -55,5 +79,22 @@ public class QuickhackSync {
             }
             i += 1;
         }
+    }
+
+    public static func OnBreachResult(peerId: Uint32, mask: Uint8) -> Void {
+        if (mask & 1u) != 0u {
+            armourTimer = 30.0;
+            HeatSync.ApplyArmorDebuff(0.7);
+            LogChannel(n"DEBUG", "Daemon armour debuff 30s");
+        };
+        if (mask & 2u) != 0u {
+            cameraTimer = 90.0;
+            LogChannel(n"DEBUG", "Daemon cameras disabled for 90s"); // future work
+        };
+        if (mask & 4u) != 0u {
+            vulnTimer = 30.0;
+            HeatSync.ApplyDamageBuff(1.2);
+            LogChannel(n"DEBUG", "Daemon mass vulnerability 30s");
+        };
     }
 }

--- a/cp2077-coop/src/runtime/Respawn.reds
+++ b/cp2077-coop/src/runtime/Respawn.reds
@@ -9,23 +9,37 @@ public class Respawn {
 
     public static func RequestRespawn(peerId: Uint32) -> Void {
         LogChannel(n"DEBUG", "RequestRespawn " + IntToString(peerId));
-        // Start timer to call PerformRespawn after delay.
+        GameInstance.GetDelaySystem(GetGame()).DelayCallback(Respawn, n"PerformRespawn", Cast<Float>(kRespawnDelayMs) / 1000.0, peerId);
     }
 
     public static func PerformRespawn(peerId: Uint32) -> Void {
-        let idx: Int32 = RandRange(0, spawnPoints.Size());
-        LogChannel(n"DEBUG", "PerformRespawn " + IntToString(peerId) + " -> " + VectorToString(spawnPoints[idx]));
+        let players = GameInstance.GetPlayerSystem(GetGame()).GetPlayers();
+        let bestIdx: Int32 = 0;
+        var bestScore: Float = -1.0;
+        for i in 0 ..< spawnPoints.Size() {
+            var minDist: Float = 10000.0;
+            for p in players {
+                if p.peerId != peerId {
+                    let d = VectorLength(spawnPoints[i] - p.pos);
+                    if d < minDist { minDist = d; };
+                };
+            };
+            if minDist > bestScore { bestScore = minDist; bestIdx = i; };
+        };
+        LogChannel(n"DEBUG", "PerformRespawn " + IntToString(peerId) + " -> " + VectorToString(spawnPoints[bestIdx]));
         let avatar = GameInstance.GetPlayerSystem(GetGame()).FindObject(peerId) as AvatarProxy;
         if IsDefined(avatar) {
-            avatar.pos = spawnPoints[idx];
+            avatar.pos = spawnPoints[bestIdx];
             avatar.vel = new Vector3(0.0, 0.0, 0.0);
             avatar.health = 100u;
             avatar.armor = 100u;
             avatar.OnVitalsChanged();
+            if HasMethod(avatar, n"SetGodMode") { avatar.SetGodMode(true); };
+            GameInstance.GetDelaySystem(GetGame()).DelayCallback(avatar, n"ClearInvuln", 2.0);
         }
         let board = DMScoreboard.Instance();
         board.deaths += 1u;
         board.Update(peerId, board.kills, board.deaths);
-        CoopNet.AddScore(peerId, board.kills, board.deaths);
+        CoopNet.AddStats(peerId, board.kills, board.deaths, 0u, 0u, 0u);
     }
 }

--- a/cp2077-coop/src/runtime/SpatialGrid.reds
+++ b/cp2077-coop/src/runtime/SpatialGrid.reds
@@ -1,0 +1,108 @@
+// flat grid impl ☠ TO-BE-REPLACED
+public class SpatialGrid {
+    public struct QuadNode {
+        public let bounds: Box;
+        public let ids: array<Uint32>;
+        public let child: array<ref<QuadNode>>;
+    }
+
+    private let root: ref<QuadNode>;
+    private let kNodeCapacity: Uint32 = 32u;
+    private let kMaxDepth: Uint32 = 6u;
+
+    public func Reset(size: Float) -> Void {
+        root = new QuadNode();
+        root.bounds.Min = Vector3{-size, -size, -100.0};
+        root.bounds.Max = Vector3{size, size, 100.0};
+    }
+
+    public func Insert(id: Uint32, pos: Vector3) -> Void {
+        if !IsDefined(root) { Reset(512.0); }; // 1 km^2 default
+        InsertRec(root, id, pos, 0u);
+    }
+
+    public func Remove(id: Uint32, pos: Vector3) -> Void {
+        if IsDefined(root) { RemoveRec(root, id, pos); };
+    }
+
+    public func Move(id: Uint32, oldPos: Vector3, newPos: Vector3) -> Void {
+        Remove(id, oldPos);
+        Insert(id, newPos);
+    }
+
+    public func QueryCircle(center: Vector3, radius: Float, out ids: array<Uint32>) -> Void {
+        ids.Clear();
+        if IsDefined(root) { QueryRec(root, center, radius, ids); };
+    }
+
+    public func IterateDF(cb: script_ref<SpatialGridQuadCb>) -> Void {
+        if IsDefined(root) { VisitRec(root, 0u, cb); };
+    }
+
+    public struct SpatialGridQuadCb {
+        public func Call(node: ref<QuadNode>, depth: Uint32);
+    }
+
+    private func InsertRec(node: ref<QuadNode>, id: Uint32, pos: Vector3, depth: Uint32) -> Void {
+        if depth >= kMaxDepth || node.child.Size() == 0 && node.ids.Size() < Cast<Int32>(kNodeCapacity) {
+            node.ids.PushBack(id);
+            return;
+        };
+        if node.child.Size() == 0 { Subdivide(node, depth); };
+        for child in node.child {
+            if PtInBox(pos, child.bounds) {
+                InsertRec(child, id, pos, depth + 1u);
+                return;
+            };
+        };
+        node.ids.PushBack(id); // fallback
+    }
+
+    private func RemoveRec(node: ref<QuadNode>, id: Uint32, pos: Vector3) -> Bool {
+        let idx = node.ids.Find(id);
+        if idx >= 0 { node.ids.Erase(idx); return true; };
+        for child in node.child {
+            if PtInBox(pos, child.bounds) {
+                if RemoveRec(child, id, pos) { return true; };
+            };
+        };
+        return false;
+    }
+
+    private func QueryRec(node: ref<QuadNode>, center: Vector3, radius: Float, out ids: array<Uint32>) -> Void {
+        if !CircleIntersectsBox(center, radius, node.bounds) { return; };
+        for id in node.ids { ids.PushBack(id); };
+        for child in node.child { QueryRec(child, center, radius, ids); };
+    }
+
+    private func VisitRec(node: ref<QuadNode>, depth: Uint32, cb: script_ref<SpatialGridQuadCb>) -> Void {
+        cb.Call(node, depth);
+        for child in node.child { VisitRec(child, depth + 1u, cb); };
+    }
+
+    private func Subdivide(node: ref<QuadNode>, depth: Uint32) -> Void {
+        node.child.Clear();
+        let half: Vector3 = (node.bounds.Max - node.bounds.Min) * 0.5;
+        let origin: Vector3 = node.bounds.Min;
+        for i in 0 .. 4 {
+            let c = new QuadNode();
+            let offsetX: Float = i % 2 == 0 ? 0.0 : half.X;
+            let offsetY: Float = i < 2 ? 0.0 : half.Y;
+            c.bounds.Min = Vector3{origin.X + offsetX, origin.Y + offsetY, -100.0};
+            c.bounds.Max = c.bounds.Min + Vector3{half.X, half.Y, 200.0};
+            node.child.PushBack(c);
+        };
+    }
+
+    private static func PtInBox(p: Vector3, b: Box) -> Bool {
+        return p.X >= b.Min.X && p.X <= b.Max.X && p.Y >= b.Min.Y && p.Y <= b.Max.Y;
+    }
+
+    private static func CircleIntersectsBox(c: Vector3, r: Float, b: Box) -> Bool {
+        let x = Max(b.Min.X, Min(c.X, b.Max.X));
+        let y = Max(b.Min.Y, Min(c.Y, b.Max.Y));
+        let dx = c.X - x;
+        let dy = c.Y - y;
+        return (dx*dx + dy*dy) <= r*r;
+    }
+}

--- a/cp2077-coop/src/runtime/SpectatorCam.reds
+++ b/cp2077-coop/src/runtime/SpectatorCam.reds
@@ -1,0 +1,61 @@
+public class SpectatorCam {
+    private static let hud: ref<SpectatorHUD>;
+    private static let target: Uint32;
+    // Switches the local player into spectator mode and disables standard HUD.
+    public static func Enter(peerId: Uint32) -> Void {
+        GameModeManager.current = GameModeManager.GameMode.Spectate;
+        let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject();
+        if IsDefined(player) {
+            if HasMethod(player, n"DisableCollision") {
+                player.DisableCollision();
+            };
+        };
+        let hudMgr = GameInstance.GetHUDManager(GetGame());
+        let list = hudMgr.GetLayers();
+        for layer in list { layer.SetVisible(false); };
+        hud = hudMgr.SpawnChildFromExternal(n"SpectatorHUD") as SpectatorHUD;
+        if IsDefined(hud) { hud.SetTarget(peerId); };
+        target = peerId;
+        LogChannel(n"DEBUG", "EnterSpectate " + IntToString(peerId));
+    }
+
+    // Very simple free-fly camera controls using WASD.
+    public static func UpdateInput(dt: Float) -> Void {
+        if GameModeManager.current != GameModeManager.GameMode.Spectate { return; };
+        let inputSys = GameInstance.GetInputSystem(GetGame());
+        let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject();
+        if !IsDefined(player) { return; };
+        var dir = Vector4.EmptyVector();
+        if inputSys.IsActionHeld(EInputKey.IK_W) { dir.Y += 1.0; };
+        if inputSys.IsActionHeld(EInputKey.IK_S) { dir.Y -= 1.0; };
+        if inputSys.IsActionHeld(EInputKey.IK_A) { dir.X -= 1.0; };
+        if inputSys.IsActionHeld(EInputKey.IK_D) { dir.X += 1.0; };
+        if Length(dir) > 0.0 {
+            dir = Vector4.Normalize(dir);
+            player.SetWorldPosition(player.GetWorldPosition() + AsVector3(dir) * (dt * 6.0));
+        };
+        if IsDefined(hud) { hud.OnUpdate(dt); };
+    }
+
+    public static func CycleTarget() -> Void {
+        let conns = Net_GetConnections();
+        if conns.Size() == 0 { return; };
+        var idx: Int32 = 0;
+        for i in 0 ..< conns.Size() {
+            if conns[i].peerId == target { idx = i + 1; break; };
+        };
+        if idx >= conns.Size() { idx = 0; };
+        target = conns[idx].peerId;
+        if IsDefined(hud) { hud.SetTarget(target); };
+    }
+}
+
+// Console command: /spectate <peerId>
+public static exec func Spectate(peerId: Int32) -> Void {
+    Net_SendSpectateRequest(Cast<Uint32>(peerId));
+}
+
+public static func SpectatorCam_Enter(peerId: Uint32) -> Void {
+    SpectatorCam.Enter(peerId);
+}
+

--- a/cp2077-coop/src/runtime/UIPauseAudit.reds
+++ b/cp2077-coop/src/runtime/UIPauseAudit.reds
@@ -1,0 +1,68 @@
+// Audits menus that pause gameplay and redirects unsafe ones.
+public class UIPauseAudit {
+    public static let blockedMenus: array<CName> = [n"WorldMap", n"Journal", n"Shards"];
+    private static let discovered: array<CName>;
+
+    public static func Audit(layer: ref<inkMenuLayer>) -> Void {
+        let name = layer.GetName();
+        if layer.IsPausesGame() && !ArrayContains(blockedMenus, name) {
+            discovered.PushBack(name);
+            LogChannel(n"DEBUG", "[UIPauseAudit] found pausing menu " + NameToString(name));
+        };
+    }
+
+    public static func OnHoloStart(peerId: Uint32) -> Void {
+        LogChannel(n"DEBUG", "HoloCall start peer=" + IntToString(Cast<Int32>(peerId)));
+        if peerId != (GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject() as AvatarProxy).peerId {
+            HoloBars.Show();
+        };
+    }
+
+    public static func OnHoloEnd(peerId: Uint32) -> Void {
+        LogChannel(n"DEBUG", "HoloCall end peer=" + IntToString(Cast<Int32>(peerId)));
+        HoloBars.Hide();
+    }
+}
+
+@wrapMethod(inkMenuLayer)
+protected cb func OnOpen(prev: wref<inkMenuLayer>) -> Void {
+    let menuName = this.GetName();
+    if menuName == n"WorldMap" {
+        CoopMap.Show();
+        return; // skip original to avoid pause
+    };
+    wrappedMethod(prev);
+    UIPauseAudit.Audit(this);
+}
+
+@wrapMethod(phonePhoneSystem)
+protected func StartCall(arg: variant) -> Void {
+    wrappedMethod(arg);
+    let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject() as AvatarProxy;
+    Net_BroadcastHoloCallStart(player.peerId);
+}
+
+@wrapMethod(phonePhoneSystem)
+protected func EndCall() -> Void {
+    wrappedMethod();
+    let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject() as AvatarProxy;
+    Net_BroadcastHoloCallEnd(player.peerId);
+}
+
+// Shard reading replaced with notice in co-op.
+@wrapMethod(ShardUI)
+protected func ShowShard(data: ref<IScriptable>) -> Void {
+    if GameModeManager.current == GameMode.Coop {
+        CoopNotice.Show("Shards");
+        return;
+    };
+    wrappedMethod(data);
+}
+
+public static func UIPauseAudit_OnHoloStart(peerId: Uint32) -> Void {
+    UIPauseAudit.OnHoloStart(peerId);
+}
+
+public static func UIPauseAudit_OnHoloEnd(peerId: Uint32) -> Void {
+    UIPauseAudit.OnHoloEnd(peerId);
+}

--- a/cp2077-coop/src/runtime/VehicleProxy.reds
+++ b/cp2077-coop/src/runtime/VehicleProxy.reds
@@ -1,9 +1,19 @@
 public class VehicleProxy extends gameObject {
+    public static let proxies: array<ref<VehicleProxy>>;
     public var vehicleId: Uint32;
     public var damage: Uint16;
     public var state: TransformSnap;
+    public var destroyed: Bool;
+    private var despawnDelay: Float;
     private var lastVel: Vector3;
     private var lastAccel: Vector3;
+    private var occupantPeer: Uint32;
+    private var physAcc: Float;
+
+    private static func FindProxy(id: Uint32) -> ref<VehicleProxy> {
+        for p in proxies { if p.vehicleId == id { return p; }; };
+        return null;
+    }
 
     public func Spawn(id: Uint32, transform: ref<TransformSnap>) -> Void {
         vehicleId = id;
@@ -19,22 +29,110 @@ public class VehicleProxy extends gameObject {
 
     // SeatIdx range 0-3
     public func EnterSeat(peerId: Uint32, idx: Uint8) -> Void {
+        occupantPeer = peerId;
         LogChannel(n"DEBUG", IntToString(peerId) + " entered seat " + IntToString(idx));
     }
 
-    public func ApplyDamage(d: Uint16) -> Void {
-        damage += d;
-        LogChannel(n"DEBUG", "Vehicle " + IntToString(vehicleId) + " damage=" + IntToString(damage));
+    public func RequestSeat(idx: Uint8) -> Void {
+        CoopNet.Net_SendSeatRequest(vehicleId, idx);
     }
 
-    // dtMs should equal CoopNet.kFixedDeltaMs for deterministic physics
+    public func DetachPart(partId: Uint8) -> Void {
+        switch partId {
+            case 0u:
+                LogChannel(n"DEBUG", "Detach door_L");
+                if HasComponent(n"door_L") {
+                    SetMeshVisibility(n"door_L", false);
+                };
+            case 1u:
+                LogChannel(n"DEBUG", "Detach door_R");
+                if HasComponent(n"door_R") {
+                    SetMeshVisibility(n"door_R", false);
+                };
+            case 2u:
+                LogChannel(n"DEBUG", "Detach hood");
+                if HasComponent(n"hood") {
+                    SetMeshVisibility(n"hood", false);
+                };
+            case 3u:
+                LogChannel(n"DEBUG", "Detach trunk");
+                if HasComponent(n"trunk") {
+                    SetMeshVisibility(n"trunk", false);
+                };
+            default:
+        };
+    }
+
+    public func Explode(vfxId: Uint32, seed: Uint32) -> Void {
+        if destroyed { return; };
+        destroyed = true;
+        despawnDelay = 10.0;
+        let effSys = GameInstance.GetScriptableSystemsContainer(GetGame()).Get(n"EffectSystem") as EffectSystem;
+        if IsDefined(effSys) {
+            effSys.SpawnEffect(vfxId, state.pos);
+        };
+        // spawn debris deterministic using seed
+        let debris = 5u + Cast<Uint32>(seed % 6u);
+        let chunkVfx: Uint32 = CoopNet.Fnv1a32("veh_debris_chunk.ent");
+        for i in 0u .. debris {
+            let ang: Float = (Cast<Float>((seed >> ((i * 3u) & 15u)) & 255u) / 255.0) * 6.28;
+            let dir: Vector3 = Vector3(Cos(ang), Sin(ang), 0.5);
+            if IsDefined(effSys) {
+                effSys.SpawnEffect(chunkVfx, state.pos + dir * 0.5);
+            };
+        };
+    }
+
+    public func ApplyDamage(d: Uint16, side: Bool) -> Void {
+        damage += d;
+        LogChannel(n"DEBUG", "Vehicle " + IntToString(vehicleId) + " damage=" + IntToString(damage));
+        if side && d > 300u {
+            CoopNet.Net_BroadcastPartDetach(vehicleId, 0u); // door_L only for now
+        };
+        if Net_IsAuthoritative() && !destroyed && damage >= 1000u {
+            CoopNet.Net_BroadcastVehicleExplode(vehicleId, CoopNet.Fnv1a32("veh_explosion_big.ent"), damage);
+            destroyed = true;
+            despawnDelay = 10.0;
+        };
+    }
+
+    // dtMs may vary; physics steps at CoopNet.kVehicleStepMs
     public func Tick(dtMs: Float) -> Void {
         if Net_IsAuthoritative() {
-            CoopNet.ServerSimulate(state, dtMs);
+            physAcc += dtMs;
+            while physAcc >= CoopNet.kVehicleStepMs {
+                CoopNet.ServerSimulate(state, CoopNet.kVehicleStepMs);
+                physAcc -= CoopNet.kVehicleStepMs;
+            };
+            let newVel: Vector3 = state.vel;
+            let delta: Vector3 = newVel - lastVel;
+            var along: Float = 0.0;
+            if VectorLength(lastVel) > 0.01 {
+                along = VectorDot(delta, VectorNormalize(lastVel));
+            };
+            let decel: Float = -along / (dtMs / 1000.0);
+            if decel > 12.0 && occupantPeer != 0u {
+                CoopNet.Net_BroadcastEject(occupantPeer, lastVel);
+                occupantPeer = 0u;
+            };
+            lastAccel = newVel - lastVel;
+            lastVel = newVel;
         } else {
             ClientPredict(dtMs);
         };
-        // NetCore.BroadcastVehicleSnap(vehicleId, state);
+        if destroyed {
+            despawnDelay -= dtMs / 1000.0;
+            if despawnDelay <= 0.0 {
+                LogChannel(n"DEBUG", "Vehicle despawn " + IntToString(vehicleId));
+                var idx: Int32 = 0;
+                while idx < VehicleProxy.proxies.Size() && VehicleProxy.proxies[idx] != this {
+                    idx += 1;
+                };
+                if idx < VehicleProxy.proxies.Size() {
+                    VehicleProxy.proxies.Erase(idx);
+                };
+            };
+        };
         LogChannel(n"DEBUG", "Vehicle tick " + IntToString(vehicleId));
     }
 
@@ -42,4 +140,30 @@ public class VehicleProxy extends gameObject {
         state.pos += lastVel * (dtMs / 1000.0);
         state.vel += lastAccel * (dtMs / 1000.0);
     }
+}
+
+public static func VehicleProxy_Spawn(id: Uint32, transform: ref<TransformSnap>) -> Void {
+    let v = new VehicleProxy();
+    v.Spawn(id, transform);
+    VehicleProxy.proxies.PushBack(v);
+}
+
+public static func VehicleProxy_Explode(id: Uint32, vfxId: Uint32, seed: Uint32) -> Void {
+    let v = VehicleProxy.FindProxy(id);
+    if IsDefined(v) { v.Explode(vfxId, seed); };
+}
+
+public static func VehicleProxy_Detach(id: Uint32, part: Uint8) -> Void {
+    let v = VehicleProxy.FindProxy(id);
+    if IsDefined(v) { v.DetachPart(part); };
+}
+
+public static func VehicleProxy_EnterSeat(peerId: Uint32, seat: Uint8) -> Void {
+    let v = VehicleProxy.proxies[0]; // assume single vehicle
+    if IsDefined(v) { v.EnterSeat(peerId, seat); };
+}
+
+public static func VehicleProxy_ApplyDamage(id: Uint32, d: Uint16, side: Bool) -> Void {
+    let v = VehicleProxy.FindProxy(id);
+    if IsDefined(v) { v.ApplyDamage(d, side); };
 }

--- a/cp2077-coop/src/runtime/VendorSync.reds
+++ b/cp2077-coop/src/runtime/VendorSync.reds
@@ -1,0 +1,7 @@
+public class VendorSync {
+    public static let stock : ref<inkHashMap> = new inkHashMap();
+
+    public static func OnStock(pkt: ref<VendorStockPacket>) -> Void {
+        stock.Insert(pkt.vendorId, pkt);
+    }
+}

--- a/cp2077-coop/src/runtime/VoiceAPI.reds
+++ b/cp2077-coop/src/runtime/VoiceAPI.reds
@@ -1,0 +1,3 @@
+public class CoopVoice {
+    public static native func StartCapture(device: String) -> Bool
+}

--- a/cp2077-coop/src/runtime/WeatherSync.reds
+++ b/cp2077-coop/src/runtime/WeatherSync.reds
@@ -1,21 +1,24 @@
 // Synchronizes time of day and weather between players.
 public struct WorldState {
+    public var worldClock: Uint64;
+    public var weatherSeed: Uint32;
     public var sunAngle: Uint32; // degrees * 100
     public var weatherId: Uint8;
+    public var braindancePhase: Uint8;
 }
 
 public class WeatherSync {
     public static let lastBroadcast: Float = 0.0;
-    private static let kInterval: Float = 30.0;
+    private static let kInterval: Float = 5.0;
 
     // Called on server when world state changes or every 30 s.
     public static func Broadcast(state: ref<WorldState>) -> Void {
         // NetCore.BroadcastWorldState(state);
         lastBroadcast = EngineTime.ToFloat(GameInstance.GetTimeSystem(GetGame()).GetGameTime());
-        LogChannel(n"DEBUG", "BroadcastWorldState sun=" + IntToString(state.sunAngle));
+        LogChannel(n"DEBUG", "BroadcastWorldState clock=" + IntToString(Cast<Int64>(state.worldClock)));
     }
 
     public static func Apply(state: ref<WorldState>) -> Void {
-        LogChannel(n"DEBUG", "ApplyWorldState sun=" + IntToString(state.sunAngle));
+        LogChannel(n"DEBUG", "ApplyWorldState weather=" + IntToString(state.weatherId));
     }
 }

--- a/cp2077-coop/src/server/AdminController.cpp
+++ b/cp2077-coop/src/server/AdminController.cpp
@@ -1,0 +1,143 @@
+#include "AdminController.hpp"
+#include "../core/GameClock.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <RED4ext/RED4ext.hpp>
+#include <iostream>
+#include <sstream>
+#include <unordered_set>
+#include "../core/ThreadSafeQueue.hpp"
+#include "WebDash.hpp"
+
+namespace CoopNet {
+
+static std::unordered_set<uint32_t> g_banList;
+static ThreadSafeQueue<std::string> g_cmdQueue;
+static std::thread g_consoleThread;
+static std::atomic<bool> g_consoleRunning{false};
+
+static void GameModeManager_SetMode(uint32_t mode)
+{
+    RED4ext::ExecuteFunction("GameModeManager", "SetMode", nullptr, mode);
+}
+
+static void QuestSync_SetFreeze(bool freeze)
+{
+    RED4ext::ExecuteFunction("QuestSync", "SetFreeze", nullptr, freeze);
+}
+
+static Connection* FindConn(uint32_t peerId)
+{
+    auto conns = Net_GetConnections();
+    for (auto* c : conns)
+    {
+        if (c->peerId == peerId)
+            return c;
+    }
+    return nullptr;
+}
+
+static void DoKick(uint32_t peerId)
+{
+    if (Connection* c = FindConn(peerId))
+    {
+        Net_SendAdminCmd(c, static_cast<uint8_t>(AdminCmdType::Kick), 0);
+        Net_Disconnect(c);
+    }
+}
+
+static void DoBan(uint32_t peerId)
+{
+    g_banList.insert(peerId);
+    DoKick(peerId);
+}
+
+static void DoMute(uint32_t peerId, uint32_t secs)
+{
+    if (Connection* c = FindConn(peerId))
+    {
+        c->muteUntilMs = GameClock::GetTimeMs() + static_cast<uint64_t>(secs) * 1000ull;
+        Net_SendAdminCmd(c, static_cast<uint8_t>(AdminCmdType::Mute), secs);
+    }
+}
+
+static void ConsoleThread()
+{
+    while (g_consoleRunning)
+    {
+        std::string line;
+        std::getline(std::cin, line);
+        if (!line.empty())
+            g_cmdQueue.Push(line);
+    }
+}
+
+void AdminController_Start()
+{
+    if (g_consoleRunning)
+        return;
+    g_consoleRunning = true;
+    g_consoleThread = std::thread(ConsoleThread);
+}
+
+void AdminController_Stop()
+{
+    if (!g_consoleRunning)
+        return;
+    g_consoleRunning = false;
+    if (g_consoleThread.joinable())
+        g_consoleThread.join();
+}
+
+void AdminController_PollCommands()
+{
+    std::string line;
+    if (!g_cmdQueue.Pop(line))
+        return;
+    std::stringstream ss(line);
+    std::string cmd;
+    ss >> cmd;
+    if (cmd == "kick")
+    {
+        uint32_t id;
+        if (ss >> id)
+        {
+            DoKick(id);
+            WebDash_PushEvent("{\"event\":\"kick\",\"id\":" + std::to_string(id) + "}");
+        }
+    }
+    else if (cmd == "ban")
+    {
+        uint32_t id;
+        if (ss >> id)
+        {
+            DoBan(id);
+            WebDash_PushEvent("{\"event\":\"ban\",\"id\":" + std::to_string(id) + "}");
+        }
+    }
+    else if (cmd == "mute")
+    {
+        uint32_t id, secs;
+        if (ss >> id >> secs)
+        {
+            DoMute(id, secs);
+            WebDash_PushEvent("{\"event\":\"mute\",\"id\":" + std::to_string(id) + "}");
+        }
+    }
+    else if (cmd == "sv_dm")
+    {
+        int flag = 0;
+        if (ss >> flag)
+        {
+            GameModeManager_SetMode(flag ? 1u : 0u);
+            QuestSync_SetFreeze(flag != 0);
+        }
+    }
+}
+
+bool AdminController_IsBanned(uint32_t peerId)
+{
+    return g_banList.count(peerId) != 0;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/AdminController.hpp
+++ b/cp2077-coop/src/server/AdminController.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "../net/Connection.hpp"
+#include <cstdint>
+
+namespace CoopNet {
+
+enum class AdminCmdType : uint8_t { Kick = 0, Ban = 1, Mute = 2 };
+
+void AdminController_Start();
+void AdminController_Stop();
+void AdminController_PollCommands();
+bool AdminController_IsBanned(uint32_t peerId);
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/BreachController.cpp
+++ b/cp2077-coop/src/server/BreachController.cpp
@@ -1,0 +1,51 @@
+#include "BreachController.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <cstdlib>
+#include <iostream>
+
+namespace CoopNet {
+
+static bool g_active = false;
+static uint32_t g_seed = 0;
+static uint8_t g_w = 0;
+static uint8_t g_h = 0;
+static float g_timer = 0.f;
+static uint32_t g_peer = 0;
+
+void BreachController_Start(uint32_t peerId, uint8_t w, uint8_t h)
+{
+    g_active = true;
+    g_seed = static_cast<uint32_t>(std::rand());
+    g_w = w;
+    g_h = h;
+    g_timer = 45.f;
+    g_peer = peerId;
+    BreachStartPacket pkt{peerId, g_seed, w, h, {0,0}};
+    Net_Broadcast(EMsg::BreachStart, &pkt, sizeof(pkt));
+    std::cout << "Breach start seed=" << g_seed << std::endl;
+}
+
+void BreachController_HandleInput(uint32_t peerId, uint8_t idx)
+{
+    if (!g_active)
+        return;
+    BreachInputPacket pkt{peerId, idx, {0,0,0}};
+    Net_Broadcast(EMsg::BreachInput, &pkt, sizeof(pkt));
+}
+
+void BreachController_ServerTick(float dt)
+{
+    if (!g_active)
+        return;
+    g_timer -= dt / 1000.f;
+    if (g_timer <= 0.f)
+    {
+        g_active = false;
+        BreachResultPacket pkt{g_peer, 7u, {0,0,0}}; // all daemons active
+        Net_Broadcast(EMsg::BreachResult, &pkt, sizeof(pkt));
+        std::cout << "Breach result sent" << std::endl;
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/BreachController.hpp
+++ b/cp2077-coop/src/server/BreachController.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet {
+void BreachController_Start(uint32_t peerId, uint8_t w, uint8_t h);
+void BreachController_HandleInput(uint32_t peerId, uint8_t idx);
+void BreachController_ServerTick(float dt);
+}

--- a/cp2077-coop/src/server/DedicatedMain.cpp
+++ b/cp2077-coop/src/server/DedicatedMain.cpp
@@ -1,10 +1,18 @@
-#include "../net/Net.hpp"
 #include "../core/GameClock.hpp"
+#include "../core/SessionState.hpp"
+#include "../core/SaveMigration.hpp"
+#include "../net/Net.hpp"
+#include "BreachController.hpp"
+#include "ElevatorController.hpp"
 #include "NpcController.hpp"
-#include <iostream>
+#include "VehicleController.hpp"
+#include "AdminController.hpp"
+#include "Heartbeat.hpp"
+#include "WebDash.hpp"
+#include "GlobalEventController.hpp"
 #include <cstring>
+#include <iostream>
 #include <thread>
-
 
 int main(int argc, char** argv)
 {
@@ -17,18 +25,118 @@ int main(int argc, char** argv)
     }
 
     Net_Init();
+    CoopNet::MigrateSinglePlayerSave();
+    CoopNet::TransformSnap vs{ {0.f,0.f,0.f}, {0.f,0.f,0.f,1.f}, {0.f,0.f,0.f} };
+    CoopNet::VehicleController_Spawn(CoopNet::Fnv1a32("vehicle_caliburn"), 0u, vs);
+    CoopNet::WebDash_Start();
+    CoopNet::AdminController_Start();
     std::cout << "Dedicated up" << std::endl;
+    uint32_t sessionId = 0;
+    uint64_t worldClock = 0;
+    uint32_t sunAngle = 0;
+    uint32_t weatherSeed = 1u;
+    uint8_t weatherId = 0u;
+    uint8_t bdPhase = 0u;
+    float worldTimer = 0.f;
 
-    // Main server loop placeholder
-    for (int i = 0; i < 10; ++i)
+    // Main server loop
+    bool running = true;
+    uint32_t idleTicks = 0;
+    float frameAccum = 0.f;
+    int frameCount = 0;
+    float goodTime = 0.f;
+    float hbTimer = 0.f;
+    float tickMs = CoopNet::GameClock::GetTickMs();
+    bool validated = false;
+    auto last = std::chrono::steady_clock::now();
+
+    while (running)
     {
-        CoopNet::GameClock::Tick(CoopNet::kFixedDeltaMs);
-        CoopNet::NpcController_ServerTick(CoopNet::kFixedDeltaMs);
-        Net_Poll(static_cast<uint32_t>(CoopNet::kFixedDeltaMs));
-        std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(CoopNet::kFixedDeltaMs)));
+        auto begin = std::chrono::steady_clock::now();
+        if (sessionId == 0)
+            sessionId = CoopNet::SessionState_GetId();
+        if (sessionId && !validated)
+        {
+            CoopNet::ValidateSessionState(sessionId);
+            validated = true;
+        }
+
+        CoopNet::GameClock::Tick(tickMs);
+        worldClock += static_cast<uint64_t>(tickMs);
+        sunAngle = (sunAngle + static_cast<uint32_t>(tickMs)) % 36000;
+        worldTimer += tickMs / 1000.f;
+        if (worldTimer >= 5.f)
+        {
+            worldTimer = 0.f;
+            Net_BroadcastWorldState(worldClock, sunAngle, weatherId, weatherSeed, bdPhase);
+        }
+        CoopNet::ElevatorController_ServerTick(tickMs);
+        if (!CoopNet::ElevatorController_IsPaused())
+        {
+            CoopNet::NpcController_ServerTick(tickMs);
+            CoopNet::VehicleController_ServerTick(tickMs);
+            CoopNet::BreachController_ServerTick(tickMs);
+            CoopNet::VendorController_Tick(tickMs);
+            RED4ext::ExecuteFunction("GameModeManager", "TickDM", nullptr, static_cast<uint32_t>(tickMs));
+        }
+        Net_Poll(static_cast<uint32_t>(tickMs));
+        CoopNet::AdminController_PollCommands();
+        hbTimer += tickMs / 1000.f;
+        if (hbTimer >= 30.f)
+        {
+            hbTimer = 0.f;
+            size_t count = Net_GetConnections().size();
+            uint32_t id = CoopNet::SessionState_GetId();
+            std::string json = "{\"players\":" + std::to_string(count) + ",\"hash\":" + std::to_string(id) + "}";
+            CoopNet::Heartbeat_Announce(json);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(tickMs)));
+
+        auto end = std::chrono::steady_clock::now();
+        float frameMs = std::chrono::duration<float, std::milli>(end - begin).count();
+        frameAccum += frameMs;
+        frameCount++;
+        if (frameAccum >= 1000.f)
+        {
+            float avg = frameAccum / frameCount;
+            frameAccum = 0.f;
+            frameCount = 0;
+            if (avg > 25.f && tickMs < 40.f)
+            {
+                tickMs = 40.f;
+                CoopNet::GameClock::SetTickMs(tickMs);
+                Net_BroadcastTickRateChange(static_cast<uint16_t>(tickMs));
+                goodTime = 0.f;
+            }
+            else
+            {
+                if (avg < 12.f)
+                    goodTime += 1.f;
+                else
+                    goodTime = 0.f;
+                if (goodTime >= 2.f && tickMs > 25.f)
+                {
+                    tickMs = 25.f;
+                    CoopNet::GameClock::SetTickMs(tickMs);
+                    Net_BroadcastTickRateChange(static_cast<uint16_t>(tickMs));
+                }
+            }
+        }
+
+        if (Net_GetConnections().empty())
+        {
+            if (++idleTicks > 300)
+                running = false;
+        }
+        else
+        {
+            idleTicks = 0;
+        }
     }
 
+    CoopNet::SaveSessionState(sessionId);
+    CoopNet::AdminController_Stop();
+    CoopNet::WebDash_Stop();
     Net_Shutdown();
     return 0;
 }
-

--- a/cp2077-coop/src/server/ElevatorController.cpp
+++ b/cp2077-coop/src/server/ElevatorController.cpp
@@ -1,0 +1,76 @@
+#include "ElevatorController.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <unordered_set>
+#include <iostream>
+
+namespace CoopNet {
+
+struct ArrivalState {
+    bool active = false;
+    ElevatorArrivePacket pkt{};
+    float timer = 0.f;
+    int retries = 0;
+    std::unordered_set<Connection*> acks;
+};
+
+static ArrivalState g_arrive;
+
+void ElevatorController_OnCall(uint32_t peerId, uint32_t elevatorId, uint8_t floor)
+{
+    ElevatorCallPacket pkt{peerId, elevatorId, floor, {0,0,0}};
+    Net_Broadcast(EMsg::ElevatorCall, &pkt, sizeof(pkt));
+}
+
+void ElevatorController_OnArrive(uint32_t elevatorId, uint64_t sectorHash, const RED4ext::Vector3& pos)
+{
+    g_arrive.active = true;
+    g_arrive.pkt.elevatorId = elevatorId;
+    g_arrive.pkt.sectorHash = sectorHash;
+    g_arrive.pkt.pos = pos;
+    g_arrive.timer = 8.f;
+    g_arrive.retries = 0;
+    g_arrive.acks.clear();
+    Net_Broadcast(EMsg::ElevatorArrive, &g_arrive.pkt, sizeof(g_arrive.pkt));
+}
+
+void ElevatorController_OnAck(Connection* conn, uint32_t elevatorId)
+{
+    if (g_arrive.active && g_arrive.pkt.elevatorId == elevatorId)
+        g_arrive.acks.insert(conn);
+}
+
+bool ElevatorController_IsPaused()
+{
+    return g_arrive.active && g_arrive.retries > 0 &&
+           g_arrive.acks.size() < Net_GetConnections().size();
+}
+
+void ElevatorController_ServerTick(float dt)
+{
+    if (!g_arrive.active)
+        return;
+    if (g_arrive.acks.size() == Net_GetConnections().size())
+    {
+        g_arrive.active = false;
+        g_arrive.acks.clear();
+        return;
+    }
+    g_arrive.timer -= dt / 1000.f;
+    if (g_arrive.timer <= 0.f)
+    {
+        if (g_arrive.retries >= 3)
+        {
+            g_arrive.active = false;
+            g_arrive.acks.clear();
+        }
+        else
+        {
+            Net_Broadcast(EMsg::ElevatorArrive, &g_arrive.pkt, sizeof(g_arrive.pkt));
+            g_arrive.retries++;
+            g_arrive.timer = 8.f;
+        }
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/ElevatorController.hpp
+++ b/cp2077-coop/src/server/ElevatorController.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "../net/Packets.hpp"
+#include "../net/Connection.hpp"
+#include <RED4ext/Scripting/Natives/Generated/Vector3.hpp>
+#include <cstdint>
+
+namespace CoopNet {
+void ElevatorController_OnCall(uint32_t peerId, uint32_t elevatorId, uint8_t floorIdx);
+void ElevatorController_OnArrive(uint32_t elevatorId, uint64_t sectorHash, const RED4ext::Vector3& pos);
+void ElevatorController_OnAck(Connection* conn, uint32_t elevatorId);
+void ElevatorController_ServerTick(float dt);
+bool ElevatorController_IsPaused();
+}

--- a/cp2077-coop/src/server/GlobalEventController.cpp
+++ b/cp2077-coop/src/server/GlobalEventController.cpp
@@ -1,0 +1,22 @@
+#include "GlobalEventController.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <iostream>
+
+namespace CoopNet {
+
+void GlobalEvent_Start(uint32_t eventId, uint8_t phase, uint32_t seed)
+{
+    GlobalEventPacket pkt{eventId, seed, phase, 1u, {0,0}};
+    Net_Broadcast(EMsg::GlobalEvent, &pkt, sizeof(pkt));
+    std::cout << "Global event start " << eventId << std::endl;
+}
+
+void GlobalEvent_Stop(uint32_t eventId, uint8_t phase)
+{
+    GlobalEventPacket pkt{eventId, 0u, phase, 0u, {0,0}};
+    Net_Broadcast(EMsg::GlobalEvent, &pkt, sizeof(pkt));
+    std::cout << "Global event stop " << eventId << std::endl;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/GlobalEventController.hpp
+++ b/cp2077-coop/src/server/GlobalEventController.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet {
+void GlobalEvent_Start(uint32_t eventId, uint8_t phase, uint32_t seed);
+void GlobalEvent_Stop(uint32_t eventId, uint8_t phase);
+}

--- a/cp2077-coop/src/server/Heartbeat.cpp
+++ b/cp2077-coop/src/server/Heartbeat.cpp
@@ -1,9 +1,57 @@
+#include "Heartbeat.hpp"
+#include "../net/NatClient.hpp"
+#include "../../third_party/httplib.h"
+#include <chrono>
+#include <thread>
 #include <iostream>
-#include <cstdint>
 
-// Sends JSON heartbeat to master server every 30 seconds.
-void SendHeartbeat(uint64_t sessionId)
+namespace CoopNet {
+static int g_backoff = 1;
+
+void Heartbeat_Send(const std::string& sessionJson)
 {
-    std::cout << "Heartbeat {\"id\":" << sessionId << ",\"ts\":...}" << std::endl;
-    // Entry should be removed after 90 s of inactivity.
+    httplib::SSLClient cli("coop-master", 443);
+    auto res = cli.Post("/api/heartbeat", sessionJson, "application/json");
+    if (!res || res->status != 200)
+    {
+        std::cerr << "Heartbeat failed" << std::endl;
+        std::this_thread::sleep_for(std::chrono::seconds(g_backoff));
+        if (g_backoff < 32)
+            g_backoff *= 2;
+        return;
+    }
+    g_backoff = 1;
+    const std::string& body = res->body;
+    if (body.find("\"ok\":true") != std::string::npos)
+    {
+        size_t u = body.find("\"url\":\"");
+        if (u != std::string::npos)
+        {
+            size_t start = u + 7;
+            size_t end = body.find('"', start);
+            std::string url = body.substr(start, end - start);
+            size_t hostPos = url.find(':', 5);
+            std::string host = url.substr(5, hostPos - 5);
+            int port = std::stoi(url.substr(hostPos + 1));
+            size_t uu = body.find("\"u\":\"", end);
+            size_t uend = body.find('"', uu + 5);
+            std::string user = body.substr(uu + 5, uend - (uu + 5));
+            size_t pp = body.find("\"p\":\"", uend);
+            size_t pend = body.find('"', pp + 5);
+            std::string pass = body.substr(pp + 5, pend - (pp + 5));
+            Nat_SetTurnCreds(host, port, user, pass);
+        }
+    }
 }
+
+void Heartbeat_Announce(const std::string& json)
+{
+    httplib::SSLClient cli("coop-master", 443);
+    auto res = cli.Post("/announce", json, "application/json");
+    if (!res || res->status != 200)
+    {
+        std::cerr << "Announce failed" << std::endl;
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/Heartbeat.hpp
+++ b/cp2077-coop/src/server/Heartbeat.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <string>
+namespace CoopNet {
+void Heartbeat_Send(const std::string& sessionJson);
+void Heartbeat_Announce(const std::string& json);
+}

--- a/cp2077-coop/src/server/InventoryController.cpp
+++ b/cp2077-coop/src/server/InventoryController.cpp
@@ -1,0 +1,90 @@
+#include "InventoryController.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <cstring>
+#include <iostream>
+#include <unordered_map>
+
+namespace CoopNet
+{
+
+static uint64_t g_nextItemId = 1;
+static std::unordered_map<uint64_t, ItemSnap> g_items;
+
+static bool ValidateMaterials(uint32_t recipe)
+{
+    // Placeholder validation: succeed if recipe > 0 which implies mats available
+    return recipe > 0;
+}
+
+static ItemSnap CraftItem(uint32_t recipe)
+{
+    ItemSnap snap{};
+    snap.itemId = g_nextItemId++;
+    snap.ownerId = 0;
+    snap.tpl = static_cast<uint16_t>(recipe);
+    snap.level = 1;
+    snap.quality = 1;
+    std::memset(snap.rolls, 0, sizeof(snap.rolls));
+    snap.slotMask = 0;
+    std::memset(snap.attachmentIds, 0, sizeof(snap.attachmentIds));
+    g_items[snap.itemId] = snap;
+    return snap;
+}
+
+ItemSnap Inventory_CreateItem(uint16_t tpl, uint32_t ownerId)
+{
+    ItemSnap snap{};
+    snap.itemId = g_nextItemId++;
+    snap.ownerId = ownerId;
+    snap.tpl = tpl;
+    snap.level = 1;
+    snap.quality = 1;
+    std::memset(snap.rolls, 0, sizeof(snap.rolls));
+    snap.slotMask = 0;
+    std::memset(snap.attachmentIds, 0, sizeof(snap.attachmentIds));
+    g_items[snap.itemId] = snap;
+    return snap;
+}
+
+static bool AttachMod(uint64_t itemId, uint8_t slot, uint64_t attachId, ItemSnap& out)
+{
+    auto it = g_items.find(itemId);
+    if (it == g_items.end() || slot >= 4)
+        return false;
+    ItemSnap& item = it->second;
+    if (item.slotMask & (1u << slot))
+        return false;
+    item.slotMask |= (1u << slot);
+    item.attachmentIds[slot] = attachId;
+    out = item;
+    return true;
+}
+
+void Inventory_HandleCraftRequest(Connection* conn, uint32_t recipeId)
+{
+    if (!ValidateMaterials(recipeId))
+        return;
+    ItemSnap snap = CraftItem(recipeId);
+    CraftResultPacket pkt{snap};
+    Net_Send(conn, EMsg::CraftResult, &pkt, sizeof(pkt));
+    ItemSnapPacket snapPkt{snap};
+    Net_Broadcast(EMsg::ItemSnap, &snapPkt, sizeof(snapPkt));
+    std::cout << "CraftRequest recipe=" << recipeId << " -> item " << snap.itemId << std::endl;
+}
+
+void Inventory_HandleAttachRequest(Connection* conn, uint64_t itemId, uint8_t slotIdx, uint64_t attachmentId)
+{
+    ItemSnap updated{};
+    bool ok = AttachMod(itemId, slotIdx, attachmentId, updated);
+    AttachModResultPacket pkt{updated, static_cast<uint8_t>(ok), {0, 0, 0}};
+    Net_Send(conn, EMsg::AttachModResult, &pkt, sizeof(pkt));
+    if (ok)
+    {
+        ItemSnapPacket snapPkt{updated};
+        Net_Broadcast(EMsg::ItemSnap, &snapPkt, sizeof(snapPkt));
+    }
+    std::cout << "AttachRequest item=" << itemId << " slot=" << static_cast<int>(slotIdx) << " ok=" << ok << std::endl;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/InventoryController.hpp
+++ b/cp2077-coop/src/server/InventoryController.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "../net/Connection.hpp"
+#include "../net/Snapshot.hpp"
+
+namespace CoopNet
+{
+
+void Inventory_HandleCraftRequest(Connection* conn, uint32_t recipeId);
+void Inventory_HandleAttachRequest(Connection* conn, uint64_t itemId, uint8_t slotIdx, uint64_t attachmentId);
+ItemSnap Inventory_CreateItem(uint16_t tpl, uint32_t ownerId);
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/LedgerService.cpp
+++ b/cp2077-coop/src/server/LedgerService.cpp
@@ -1,0 +1,43 @@
+#include "LedgerService.hpp"
+#include "../net/Connection.hpp"
+#include <unordered_map>
+
+namespace CoopNet
+{
+
+struct LedgerKey
+{
+    Connection* conn;
+    uint64_t nonce;
+};
+struct KeyHash
+{
+    size_t operator()(const LedgerKey& k) const noexcept
+    {
+        return reinterpret_cast<size_t>(k.conn) ^ std::hash<uint64_t>{}(k.nonce);
+    }
+};
+struct KeyEq
+{
+    bool operator()(const LedgerKey& a, const LedgerKey& b) const noexcept
+    {
+        return a.conn == b.conn && a.nonce == b.nonce;
+    }
+};
+
+static std::unordered_set<LedgerKey, KeyHash, KeyEq> g_processed;
+
+bool Ledger_Transfer(Connection* conn, int64_t delta, uint64_t nonce, uint64_t& outBalance)
+{
+    LedgerKey key{conn, nonce};
+    if (g_processed.find(key) != g_processed.end())
+        return false;
+    if (delta < 0 && conn->balance < static_cast<uint64_t>(-delta))
+        return false;
+    conn->balance += delta;
+    outBalance = conn->balance;
+    g_processed.insert(key);
+    return true;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/LedgerService.hpp
+++ b/cp2077-coop/src/server/LedgerService.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet
+{
+class Connection;
+
+bool Ledger_Transfer(Connection* conn, int64_t delta, uint64_t nonce, uint64_t& outBalance);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/NpcController.cpp
+++ b/cp2077-coop/src/server/NpcController.cpp
@@ -1,39 +1,141 @@
 #include "NpcController.hpp"
+#include "../core/Hash.hpp"
+#include "../core/SpatialGrid.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <RED4ext/RED4ext.hpp>
+#include <cmath>
+#include <cstring>
+#include <unordered_map>
 #include <iostream>
 
-namespace CoopNet {
+namespace CoopNet
+{
+
 static uint32_t g_seed = 123456u;
-static NpcSnap g_npc {
-    1u, // npcId
-    0u, // templateId
+static std::unordered_map<uint64_t, uint32_t> g_sectorSeeds;
+static NpcSnap g_npc{
+    1u,
+    0u,
+    0ull,
     RED4ext::Vector3{0.f, 0.f, 0.f},
     RED4ext::Quaternion{0.f, 0.f, 0.f, 1.f},
-    0u, // state idle
-    100u, // health
-    0u // appearance
+    NpcState::Idle,
+    100u,
+    0u
 };
+static bool g_alwaysRelevant = false;
 static NpcSnap g_prevSnap = g_npc;
+static SpatialGrid g_grid;
+static bool g_gridInit = false;
+static float g_walkDir = 0.f;
+static float g_dirTimer = 0.f;
+
+static uint32_t GetSectorSeed(uint64_t hash)
+{
+    auto it = g_sectorSeeds.find(hash);
+    if (it != g_sectorSeeds.end())
+        return it->second;
+    uint32_t seed = static_cast<uint32_t>(hash ^ 0xA5A5A5A5u);
+    g_sectorSeeds[hash] = seed;
+    return seed;
+}
+
+void NpcController_OnPlayerEnterSector(uint32_t peerId, uint64_t hash)
+{
+    uint32_t seed = GetSectorSeed(hash);
+    CrowdSeedPacket pkt{hash, seed};
+    Net_Broadcast(EMsg::CrowdSeed, &pkt, sizeof(pkt));
+}
+
+uint32_t NpcController_GetSectorSeed(uint64_t hash)
+{
+    return GetSectorSeed(hash);
+}
 
 void NpcController_ServerTick(float dt)
 {
-    // Deterministic RNG walk placeholder
-    g_seed = g_seed * 1664525u + 1013904223u;
-    float move = static_cast<float>(g_seed & 0xFF) / 255.0f - 0.5f;
-    g_npc.pos.X += move * dt * 0.1f;
+    if (!g_gridInit)
+    {
+        g_npc.sectorHash = Fnv1a64Pos(g_npc.pos.X, g_npc.pos.Y);
+        g_grid.Insert(g_npc.npcId, g_npc.pos);
+        g_gridInit = true;
+    }
+    // NR-2: deterministic AI walk routine
+    g_dirTimer += dt;
+    if (g_dirTimer >= 3.f)
+    {
+        g_seed = g_seed * 1664525u + 1013904223u;
+        g_walkDir = static_cast<float>(g_seed & 0xFFFF) / 65535.f * 6.283185f;
+        g_dirTimer = 0.f;
+    }
+    float speed = 0.5f; // m/s
+    g_npc.pos.X += std::cos(g_walkDir) * speed * dt;
+    g_npc.pos.Y += std::sin(g_walkDir) * speed * dt;
+    g_grid.Move(g_npc.npcId, g_prevSnap.pos, g_npc.pos);
 
     std::cout << "[NPC] tick seed=" << g_seed << " pos=" << g_npc.pos.X << std::endl;
 
-    // Broadcast snapshot if changed (placeholder broadcast)
-    if (std::memcmp(&g_prevSnap, &g_npc, sizeof(NpcSnap)) != 0)
+    bool changed = std::memcmp(&g_prevSnap, &g_npc, sizeof(NpcSnap)) != 0;
+
+    auto conns = Net_GetConnections();
+    std::vector<uint32_t> ids;
+    for (auto* c : conns)
     {
-        std::cout << "[NPC] broadcast snapshot id=" << g_npc.npcId << std::endl;
-        g_prevSnap = g_npc;
+        if (!c->sectorReady)
+            continue;
+        // Build interest set: nearby NPCs plus combatants.
+        g_grid.QueryCircle(c->avatarPos, 80.f, ids);
+        std::unordered_set<uint32_t> newSet(ids.begin(), ids.end());
+        if (g_npc.state == NpcState::Combat)
+            newSet.insert(g_npc.npcId);
+        for (uint32_t id : newSet)
+        {
+            if (c->subscribedNpcs.insert(id).second)
+            {
+                InterestPacket pkt{id};
+                Net_Send(c, EMsg::InterestAdd, &pkt, sizeof(pkt));
+            }
+        }
+        for (auto it = c->subscribedNpcs.begin(); it != c->subscribedNpcs.end();)
+        {
+            if (newSet.count(*it) == 0)
+            {
+                InterestPacket pkt{*it};
+                Net_Send(c, EMsg::InterestRemove, &pkt, sizeof(pkt));
+                it = c->subscribedNpcs.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        if (c->subscribedNpcs.count(g_npc.npcId) && changed)
+        {
+            NpcSnapshotPacket pkt{g_npc};
+            Net_Send(c, EMsg::NpcSnapshot, &pkt, sizeof(pkt));
+        }
     }
+
+    if (changed)
+        g_prevSnap = g_npc;
+    // Spatial grid reduces search complexity for interest checks
 }
 
 void NpcController_ClientApplySnap(const NpcSnap& snap)
 {
-    std::cout << "[NPC] apply snap id=" << snap.npcId << std::endl;
+    RED4ext::ExecuteFunction("NpcController", "ClientApplySnap", nullptr, &snap);
+}
+
+void NpcController_ApplyCrowdSeed(uint64_t hash, uint32_t seed)
+{
+    RED4ext::ExecuteFunction("NpcController", "ApplyCrowdSeed", nullptr, hash, seed);
+}
+
+void NpcController_Despawn(uint32_t id)
+{
+    RED4ext::ExecuteFunction("NpcController", "DespawnNpc", nullptr, id);
 }
 
 } // namespace CoopNet

--- a/cp2077-coop/src/server/NpcController.hpp
+++ b/cp2077-coop/src/server/NpcController.hpp
@@ -5,5 +5,9 @@ namespace CoopNet {
 
 void NpcController_ServerTick(float dt);
 void NpcController_ClientApplySnap(const NpcSnap& snap);
+void NpcController_Despawn(uint32_t id);
+void NpcController_OnPlayerEnterSector(uint32_t peerId, uint64_t hash);
+uint32_t NpcController_GetSectorSeed(uint64_t hash);
+void NpcController_ApplyCrowdSeed(uint64_t hash, uint32_t seed);
 
 }

--- a/cp2077-coop/src/server/VehicleController.cpp
+++ b/cp2077-coop/src/server/VehicleController.cpp
@@ -1,0 +1,121 @@
+#include "VehicleController.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include "../net/Connection.hpp"
+#include "../core/Hash.hpp"
+#include "../core/GameClock.hpp"
+#include <cmath>
+#include <iostream>
+
+namespace CoopNet {
+struct VehicleState {
+    uint32_t id = 1;
+    uint32_t archetype = 0;
+    uint32_t paint = 0;
+    TransformSnap snap{};
+    uint16_t damage = 0;
+    RED4ext::Vector3 prevVel{};
+    bool destroyed = false;
+    float despawn = 0.f;
+    uint32_t seat[4] = {0,0,0,0};
+    float lastHit = 0.f;
+};
+
+static VehicleState g_vehicle;
+
+void VehicleController_Spawn(uint32_t archetype, uint32_t paint, const TransformSnap& t)
+{
+    g_vehicle.archetype = archetype;
+    g_vehicle.paint = paint;
+    g_vehicle.snap = t;
+    g_vehicle.damage = 0;
+    g_vehicle.destroyed = false;
+    g_vehicle.despawn = 0.f;
+    for (int i = 0; i < 4; ++i)
+        g_vehicle.seat[i] = 0;
+    VehicleSpawnPacket pkt{g_vehicle.id, archetype, paint, t};
+    Net_Broadcast(EMsg::VehicleSpawn, &pkt, sizeof(pkt));
+}
+
+static float VecLen(const RED4ext::Vector3& v)
+{
+    return std::sqrt(v.X * v.X + v.Y * v.Y + v.Z * v.Z);
+}
+
+void VehicleController_ApplyDamage(uint16_t dmg, bool side)
+{
+    g_vehicle.damage += dmg;
+    if (side && dmg > 300u)
+    {
+        VehiclePartDetachPacket pkt{g_vehicle.id, 0, {0,0,0}};
+        Net_Broadcast(EMsg::VehiclePartDetach, &pkt, sizeof(pkt));
+    }
+    if (!g_vehicle.destroyed && g_vehicle.damage >= 1000u)
+    {
+        uint32_t vfx = Fnv1a32("veh_explosion_big.ent");
+        uint32_t seed = g_vehicle.damage * 1664525u + 1013904223u;
+        VehicleExplodePacket pkt{g_vehicle.id, vfx, seed};
+        Net_Broadcast(EMsg::VehicleExplode, &pkt, sizeof(pkt));
+        g_vehicle.destroyed = true;
+        g_vehicle.despawn = 10.f;
+    }
+}
+
+void VehicleController_SetOccupant(uint32_t peerId)
+{
+    g_vehicle.seat[0] = peerId;
+}
+
+void VehicleController_HandleSeatRequest(CoopNet::Connection* c, uint32_t vehicleId, uint8_t seatIdx)
+{
+    if (vehicleId != g_vehicle.id || seatIdx >= 4)
+        return;
+    if (g_vehicle.seat[seatIdx] == 0)
+    {
+        g_vehicle.seat[seatIdx] = c->peerId;
+        SeatAssignPacket pkt{c->peerId, vehicleId, seatIdx};
+        Net_Broadcast(EMsg::SeatAssign, &pkt, sizeof(pkt));
+    }
+}
+
+void VehicleController_HandleHit(uint32_t vehicleId, uint16_t dmg, bool side)
+{
+    if (vehicleId != g_vehicle.id)
+        return;
+    float now = GameClock::GetCurrentTick() * GameClock::GetTickMs();
+    if (now - g_vehicle.lastHit < 200.f)
+        return;
+    g_vehicle.lastHit = now;
+    VehicleController_ApplyDamage(dmg, side);
+    VehicleHitPacket pkt{vehicleId, dmg, side ? 1 : 0, 0};
+    Net_Broadcast(EMsg::VehicleHit, &pkt, sizeof(pkt));
+}
+
+void VehicleController_RemovePeer(uint32_t peerId)
+{
+    for (int i = 0; i < 4; ++i)
+        if (g_vehicle.seat[i] == peerId)
+            g_vehicle.seat[i] = 0;
+}
+
+void VehicleController_ServerTick(float dt)
+{
+    if (g_vehicle.destroyed)
+    {
+        g_vehicle.despawn -= dt / 1000.f;
+        return;
+    }
+    float vPrev = VecLen(g_vehicle.prevVel);
+    float vCur = VecLen(g_vehicle.snap.vel);
+    float decel = (vPrev - vCur) / (dt / 1000.f);
+    if (decel > 12.f && g_vehicle.seat[0] != 0)
+    {
+        RED4ext::Vector3 launch = g_vehicle.prevVel;
+        EjectOccupantPacket pkt{g_vehicle.seat[0], launch};
+        Net_Broadcast(EMsg::EjectOccupant, &pkt, sizeof(pkt));
+        g_vehicle.seat[0] = 0;
+    }
+    g_vehicle.prevVel = g_vehicle.snap.vel;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/VehicleController.hpp
+++ b/cp2077-coop/src/server/VehicleController.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "../net/Snapshot.hpp"
+
+namespace CoopNet {
+void VehicleController_ServerTick(float dt);
+void VehicleController_ApplyDamage(uint16_t dmg, bool side);
+void VehicleController_SetOccupant(uint32_t peerId);
+void VehicleController_Spawn(uint32_t archetype, uint32_t paint, const TransformSnap& t);
+void VehicleController_HandleSeatRequest(CoopNet::Connection* c, uint32_t vehicleId, uint8_t seatIdx);
+void VehicleController_HandleHit(uint32_t vehicleId, uint16_t dmg, bool side);
+void VehicleController_RemovePeer(uint32_t peerId);
+}

--- a/cp2077-coop/src/server/VendorController.cpp
+++ b/cp2077-coop/src/server/VendorController.cpp
@@ -1,0 +1,87 @@
+#include "VendorController.hpp"
+#include "../net/Net.hpp"
+#include "InventoryController.hpp"
+#include "LedgerService.hpp"
+#include <algorithm>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+namespace CoopNet
+{
+
+struct VendorItem
+{
+    uint32_t id;
+    uint32_t price;
+};
+static std::unordered_map<uint32_t, std::vector<VendorItem>> g_stock;
+static std::unordered_map<uint32_t, float> g_timer;
+
+void VendorController_Tick(float dt)
+{
+    for (auto& kv : g_timer)
+    {
+        kv.second += dt;
+        if (kv.second >= 1800.f)
+        {
+            kv.second = 0.f;
+            auto& list = g_stock[kv.first];
+            list.clear();
+            VendorItem item{kv.first * 10 + 1, 1000};
+            list.push_back(item);
+            VendorStockPacket pkt{};
+            pkt.vendorId = kv.first;
+            pkt.count = static_cast<uint8_t>(list.size());
+            for (size_t i = 0; i < list.size() && i < 8; ++i)
+            {
+                pkt.items[i].itemId = list[i].id;
+                pkt.items[i].price = list[i].price;
+            }
+            Net_BroadcastVendorStock(pkt);
+        }
+    }
+}
+
+static uint32_t CalculatePrice(const VendorItem& item, Connection* conn)
+{
+    // FIXME(next ticket): include street cred and perks
+    (void)conn;
+    return item.price;
+}
+
+void VendorController_HandlePurchase(Connection* conn, uint32_t vendorId, uint32_t itemId, uint64_t nonce)
+{
+    auto it = g_stock.find(vendorId);
+    if (it == g_stock.end())
+        return;
+    auto& list = it->second;
+    auto itemIt = std::find_if(list.begin(), list.end(), [&](const VendorItem& v) { return v.id == itemId; });
+    if (itemIt == list.end())
+        return;
+    uint64_t balance;
+    uint32_t price = CalculatePrice(*itemIt, conn);
+    if (!Ledger_Transfer(conn, -static_cast<int64_t>(price), nonce, balance))
+    {
+        PurchaseResultPacket res{vendorId, itemId, conn->balance, 0, {0, 0, 0}};
+        Net_Send(conn, EMsg::PurchaseResult, &res, sizeof(res));
+        return;
+    }
+    ItemSnap snap = Inventory_CreateItem(static_cast<uint16_t>(itemIt->id), conn->peerId);
+    ItemSnapPacket pkt{snap};
+    Net_Send(conn, EMsg::ItemSnap, &pkt, sizeof(pkt));
+    PurchaseResultPacket res{vendorId, itemId, balance, 1, {0, 0, 0}};
+    Net_Send(conn, EMsg::PurchaseResult, &res, sizeof(res));
+    list.erase(itemIt);
+    VendorStockPacket stock{};
+    stock.vendorId = vendorId;
+    stock.count = static_cast<uint8_t>(list.size());
+    for (size_t i = 0; i < list.size() && i < 8; ++i)
+    {
+        stock.items[i].itemId = list[i].id;
+        stock.items[i].price = list[i].price;
+    }
+    Net_BroadcastVendorStock(stock);
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/VendorController.hpp
+++ b/cp2077-coop/src/server/VendorController.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include "../net/Packets.hpp"
+
+namespace CoopNet
+{
+void VendorController_Tick(float dt);
+void VendorController_HandlePurchase(Connection* conn, uint32_t vendorId, uint32_t itemId, uint64_t nonce);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/WebDash.cpp
+++ b/cp2077-coop/src/server/WebDash.cpp
@@ -1,0 +1,165 @@
+#include "WebDash.hpp"
+#include "../net/Net.hpp"
+#include "../net/Connection.hpp"
+#include "../core/GameClock.hpp"
+#include "../core/ThreadSafeQueue.hpp"
+#include <openssl/sha.h>
+#include <openssl/evp.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <sstream>
+#include <iostream>
+
+namespace CoopNet
+{
+static std::thread g_thread;
+static std::atomic<bool> g_running{false};
+static int g_listenSock = -1;
+static std::vector<int> g_wsClients;
+static ThreadSafeQueue<std::string> g_events;
+
+// Build JSON status payload describing connected peers.
+static std::string BuildStatus()
+{
+    std::stringstream ss;
+    ss << "{\"peers\":[";
+    auto conns = Net_GetConnections();
+    for (size_t i = 0; i < conns.size(); ++i)
+    {
+        auto* c = conns[i];
+        ss << "{\"id\":" << c->peerId << ",\"hist\":[";
+        for (int h = 0; h < 16; ++h)
+        {
+            ss << c->rttHist[h];
+            if (h < 15) ss << ',';
+        }
+        ss << "],\"relay\":" << c->relayBytes
+           << ",\"pos\":" << c->avatarPos.X << "," << c->avatarPos.Y
+           << "}";
+        if (i + 1 < conns.size())
+            ss << ',';
+    }
+    ss << "]}";
+    return ss.str();
+}
+
+static const char* kPage =
+"<!DOCTYPE html><html><body><table id='peers'><tr><th>ID</th><th>Ping</th><th>Pos</th><th>Mode</th></tr></table>"
+"<script>async function p(){let r=await fetch('/status');let d=await r.json();let t=document.getElementById('peers');t.innerHTML='<tr><th>ID</th><th>Ping</th><th>Pos</th><th>Mode</th></tr>';d.peers.forEach(function(e){let r=document.createElement('tr');r.innerHTML='<td>'+e.id+'</td><td>'+e.ping+'</td><td>'+e.pos+'</td><td>'+e.mode+'</td>';t.appendChild(r);});}setInterval(p,2000);p();</script>"
+"</body></html>";
+
+static void ServerLoop()
+{
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(7788);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    g_listenSock = socket(AF_INET, SOCK_STREAM, 0);
+    if (g_listenSock < 0)
+        return;
+    int yes = 1;
+    setsockopt(g_listenSock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+    if (bind(g_listenSock, (sockaddr*)&addr, sizeof(addr)) < 0)
+        return;
+    if (listen(g_listenSock, 4) < 0)
+        return;
+
+    while (g_running)
+    {
+        int client = accept(g_listenSock, nullptr, nullptr);
+        if (client < 0)
+            continue;
+        char buf[1024];
+        int len = recv(client, buf, sizeof(buf) - 1, 0);
+        if (len <= 0)
+        {
+            close(client);
+            continue;
+        }
+        buf[len] = 0;
+        std::string req(buf, len);
+        std::string body;
+        std::string hdr;
+        if (req.rfind("GET /ws", 0) == 0 && req.find("Upgrade: websocket") != std::string::npos)
+        {
+            size_t pos = req.find("Sec-WebSocket-Key: ");
+            if (pos != std::string::npos)
+            {
+                pos += 19;
+                size_t end = req.find('\r', pos);
+                std::string key = req.substr(pos, end - pos);
+                key += "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+                unsigned char sha[20];
+                SHA1(reinterpret_cast<const unsigned char*>(key.c_str()), key.size(), sha);
+                char b64[32];
+                EVP_EncodeBlock(reinterpret_cast<unsigned char*>(b64), sha, 20);
+                std::string accept(b64);
+                hdr = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + accept + "\r\n\r\n";
+                send(client, hdr.c_str(), hdr.size(), 0);
+                g_wsClients.push_back(client);
+                continue;
+            }
+        }
+        else if (req.rfind("GET /status", 0) == 0)
+        {
+            body = BuildStatus();
+            hdr = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
+            send(client, hdr.c_str(), hdr.size(), 0);
+            send(client, body.c_str(), body.size(), 0);
+        }
+        else
+        {
+            body = kPage;
+            hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
+            send(client, hdr.c_str(), hdr.size(), 0);
+            send(client, body.c_str(), body.size(), 0);
+        }
+        close(client);
+    }
+    for (int ws : g_wsClients)
+    {
+        std::string status = BuildStatus();
+        uint8_t hdr[2]{0x81, static_cast<uint8_t>(status.size())};
+        send(ws, hdr, 2, 0);
+        send(ws, status.c_str(), status.size(), 0);
+        std::string evt;
+        while (g_events.Pop(evt))
+        {
+            uint8_t h[2]{0x81, static_cast<uint8_t>(evt.size())};
+            send(ws, h, 2, 0);
+            send(ws, evt.c_str(), evt.size(), 0);
+        }
+    }
+    close(g_listenSock);
+}
+
+void WebDash_Start()
+{
+    if (g_running)
+        return;
+    g_running = true;
+    g_thread = std::thread(ServerLoop);
+}
+
+void WebDash_Stop()
+{
+    if (!g_running)
+        return;
+    g_running = false;
+    shutdown(g_listenSock, SHUT_RDWR);
+    if (g_thread.joinable())
+        g_thread.join();
+}
+
+void WebDash_PushEvent(const std::string& json)
+{
+    g_events.Push(json);
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/WebDash.hpp
+++ b/cp2077-coop/src/server/WebDash.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet {
+void WebDash_Start();
+void WebDash_Stop();
+void WebDash_PushEvent(const std::string& json);
+}

--- a/cp2077-coop/src/voice/VoiceDecoder.cpp
+++ b/cp2077-coop/src/voice/VoiceDecoder.cpp
@@ -1,0 +1,119 @@
+#include "VoiceDecoder.hpp"
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <opus/opus.h>
+#include <vector>
+#include <AL/al.h>
+#include <AL/alc.h>
+
+namespace CoopVoice
+{
+struct JitterPkt
+{
+    uint16_t seq;
+    uint16_t size;
+    uint8_t data[256];
+};
+
+static std::vector<JitterPkt> g_buffer;
+static OpusDecoder* g_decoder = nullptr;
+static uint16_t g_lastSeq = 0;
+static ALCdevice* g_dev = nullptr;
+static ALCcontext* g_ctx = nullptr;
+static ALuint g_source = 0;
+static ALuint g_buffers[4];
+static int g_bufIndex = 0;
+
+void PushPacket(uint16_t seq, const uint8_t* data, uint16_t size)
+{
+    JitterPkt p{};
+    p.seq = seq;
+    p.size = std::min<size_t>(size, sizeof(p.data));
+    std::memcpy(p.data, data, p.size);
+    auto it = std::lower_bound(g_buffer.begin(), g_buffer.end(), seq,
+                               [](const JitterPkt& a, uint16_t s) { return a.seq < s; });
+    g_buffer.insert(it, p);
+    if (g_buffer.size() > 50)
+        g_buffer.erase(g_buffer.begin());
+}
+
+static bool NextPacket(JitterPkt& out)
+{
+    if (g_buffer.empty())
+        return false;
+    while (!g_buffer.empty() && (uint16_t)(g_lastSeq + 1 - g_buffer.front().seq) > 10)
+        g_buffer.erase(g_buffer.begin());
+    if (g_buffer.empty())
+        return false;
+    out = g_buffer.front();
+    g_lastSeq = out.seq;
+    g_buffer.erase(g_buffer.begin());
+    return true;
+}
+
+static bool EnsureAL()
+{
+    if (g_dev)
+        return true;
+    g_dev = alcOpenDevice("Generic Software");
+    if (!g_dev)
+        return false;
+    g_ctx = alcCreateContext(g_dev, nullptr);
+    if (!g_ctx)
+    {
+        alcCloseDevice(g_dev);
+        g_dev = nullptr;
+        return false;
+    }
+    alcMakeContextCurrent(g_ctx);
+    alGenSources(1, &g_source);
+    alGenBuffers(4, g_buffers);
+    g_bufIndex = 0;
+    return true;
+}
+
+int DecodeFrame(int16_t* pcmOut)
+{
+    if (!g_decoder)
+    {
+        int err = 0;
+        g_decoder = opus_decoder_create(48000, 1, &err);
+        if (err != OPUS_OK)
+            return 0;
+    }
+
+    JitterPkt pkt{};
+    if (!NextPacket(pkt))
+        return 0;
+
+    int samples = opus_decode(g_decoder, pkt.data, pkt.size, pcmOut, 960, 0);
+    if (samples < 0)
+        return 0;
+
+    if (!EnsureAL())
+        return samples;
+
+    ALint processed = 0;
+    alGetSourcei(g_source, AL_BUFFERS_PROCESSED, &processed);
+    while (processed-- > 0)
+    {
+        ALuint buf;
+        alSourceUnqueueBuffers(g_source, 1, &buf);
+    }
+    ALint queued = 0;
+    alGetSourcei(g_source, AL_BUFFERS_QUEUED, &queued);
+    if (queued > 8)
+        return samples; // drop to avoid latency
+
+    alBufferData(g_buffers[g_bufIndex], AL_FORMAT_MONO16, pcmOut,
+                 samples * sizeof(int16_t), 48000);
+    alSourceQueueBuffers(g_source, 1, &g_buffers[g_bufIndex]);
+    g_bufIndex = (g_bufIndex + 1) % 4;
+    ALint state = 0;
+    alGetSourcei(g_source, AL_SOURCE_STATE, &state);
+    if (state != AL_PLAYING)
+        alSourcePlay(g_source);
+    return samples;
+}
+} // namespace CoopVoice

--- a/cp2077-coop/src/voice/VoiceDecoder.hpp
+++ b/cp2077-coop/src/voice/VoiceDecoder.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopVoice
+{
+void PushPacket(uint16_t seq, const uint8_t* data, uint16_t size);
+int DecodeFrame(int16_t* pcmOut);
+} // namespace CoopVoice

--- a/cp2077-coop/src/voice/VoiceEncoder.cpp
+++ b/cp2077-coop/src/voice/VoiceEncoder.cpp
@@ -1,0 +1,37 @@
+#include "VoiceEncoder.hpp"
+#include "../net/Net.hpp"
+#include <cstring>
+#include <iostream>
+#include <opus/opus.h>
+
+namespace CoopVoice
+{
+static bool g_capturing = false;
+static OpusEncoder* g_encoder = nullptr;
+
+bool StartCapture(const char* deviceName)
+{
+    std::cout << "[Voice] StartCapture dev=" << (deviceName ? deviceName : "default") << std::endl;
+    int err = 0;
+    g_encoder = opus_encoder_create(48000, 1, OPUS_APPLICATION_VOIP, &err);
+    if (err != OPUS_OK)
+    {
+        std::cerr << "Failed to init Opus encoder" << std::endl;
+        return false;
+    }
+    g_capturing = true;
+    (void)deviceName; // device handling not yet implemented
+    return true;
+}
+
+int EncodeFrame(int16_t* pcm, uint8_t* outBuf)
+{
+    if (!g_capturing || !g_encoder)
+        return 0;
+    int bytes = opus_encode(g_encoder, pcm, 960, outBuf, 256);
+    if (bytes < 0)
+        return 0;
+    return bytes;
+}
+
+} // namespace CoopVoice

--- a/cp2077-coop/src/voice/VoiceEncoder.hpp
+++ b/cp2077-coop/src/voice/VoiceEncoder.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopVoice
+{
+bool StartCapture(const char* deviceName);
+int EncodeFrame(int16_t* pcm, uint8_t* outBuf);
+} // namespace CoopVoice

--- a/cp2077-coop/third_party/httplib.h
+++ b/cp2077-coop/third_party/httplib.h
@@ -1,0 +1,16 @@
+#ifndef CPP_HTTPLIB_H
+#define CPP_HTTPLIB_H
+#include <string>
+namespace httplib {
+struct Result { int status; std::string body; };
+class SSLClient {
+    std::string host; int port; bool valid;
+public:
+    SSLClient(const std::string& h, int p=443) : host(h), port(p), valid(true) {}
+    Result Post(const char* path, const std::string& body, const char* type) const {
+        (void)path;(void)body;(void)type;
+        return {200, "{\"ok\":false}"};
+    }
+};
+}
+#endif

--- a/cp2077-coop/tools/coop_merge.cpp
+++ b/cp2077-coop/tools/coop_merge.cpp
@@ -1,0 +1,173 @@
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "../src/core/SessionState.hpp"
+
+// NOTE: This utility uses rapidjson for simplicity. The header is expected to be
+// provided by the build environment.
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+using namespace rapidjson;
+
+struct SingleSave
+{
+    uint32_t xp = 0;
+    std::unordered_map<std::string, uint32_t> quests;
+    std::vector<CoopNet::ItemSnap> inventory;
+};
+
+static bool LoadJson(const std::string& path, Document& doc)
+{
+    std::ifstream in(path);
+    if (!in.is_open())
+        return false;
+    std::string data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    doc.Parse(data.c_str());
+    return !doc.HasParseError();
+}
+
+static void SaveJson(const std::string& path, const Document& doc)
+{
+    StringBuffer buffer;
+    Writer<StringBuffer> writer(buffer);
+    const_cast<Document&>(doc).Accept(writer);
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out << buffer.GetString();
+}
+
+static void MergeSaves(const Document& coop, const SingleSave& sp, Document& out, std::string& summary)
+{
+    out.SetObject();
+    auto& alloc = out.GetAllocator();
+
+    // XP
+    uint32_t coopXP = coop["xp"].GetUint();
+    uint32_t finalXP = std::max(coopXP, sp.xp);
+    out.AddMember("xp", finalXP, alloc);
+    if (finalXP != sp.xp)
+        summary += "XP updated\n";
+
+    // Quests
+    Value quests(kObjectType);
+    unsigned questDiff = 0;
+    for (auto itr = coop["quests"].MemberBegin(); itr != coop["quests"].MemberEnd(); ++itr)
+    {
+        std::string name = itr->name.GetString();
+        uint32_t stage = itr->value.GetUint();
+        auto it = sp.quests.find(name);
+        uint32_t base = it == sp.quests.end() ? 0 : it->second;
+        if (stage > base)
+            questDiff++;
+        quests.AddMember(Value(name.c_str(), alloc), stage > base ? stage : base, alloc);
+    }
+    out.AddMember("quests", quests, alloc);
+    if (questDiff)
+    {
+        summary += std::to_string(questDiff) + " quest stages updated\n";
+    }
+
+    // Inventory
+    Value inv(kArrayType);
+    Value conflicts(kArrayType);
+    unsigned added = 0;
+    for (auto& c : coop["inventory"].GetArray())
+    {
+        uint32_t id = c["itemId"].GetUint();
+        uint16_t qty = static_cast<uint16_t>(c["qty"].GetUint());
+        bool merged = false;
+        for (auto& item : sp.inventory)
+        {
+            if (item.itemId == id)
+            {
+                if (item.quantity != qty)
+                {
+                    std::string desc = "Item " + std::to_string(id) + " qty " + std::to_string(item.quantity) + " vs " + std::to_string(qty);
+                    conflicts.PushBack(Value(desc.c_str(), alloc), alloc);
+                }
+                merged = true;
+                Value entry(kObjectType);
+                uint16_t finalQty = std::max(item.quantity, qty);
+                entry.AddMember("itemId", id, alloc);
+                entry.AddMember("qty", finalQty, alloc);
+                inv.PushBack(entry, alloc);
+                break;
+            }
+        }
+        if (!merged)
+        {
+            inv.PushBack(c, alloc);
+        }
+    }
+    for (auto& item : sp.inventory)
+    {
+        bool found = false;
+        for (auto& c : coop["inventory"].GetArray())
+        {
+            if (c["itemId"].GetUint() == item.itemId)
+            {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+        {
+            Value entry(kObjectType);
+            entry.AddMember("itemId", item.itemId, alloc);
+            entry.AddMember("qty", item.quantity, alloc);
+            inv.PushBack(entry, alloc);
+            added++;
+        }
+    }
+    out.AddMember("inventory", inv, alloc);
+    if (conflicts.Size() > 0)
+        out.AddMember("conflicts", conflicts, alloc);
+    if (added)
+        summary += std::to_string(added) + " items added\n";
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 3)
+    {
+        std::cout << "Usage: coop_merge <session.json> <singleplayerSave.dat>\n";
+        return 1;
+    }
+
+    Document coopDoc;
+    if (!LoadJson(argv[1], coopDoc))
+    {
+        std::cerr << "Failed to read session JSON" << std::endl;
+        return 1;
+    }
+
+    // Stub: treat the singleplayer save as JSON as well
+    Document spDoc;
+    if (!LoadJson(argv[2], spDoc))
+    {
+        std::cerr << "Failed to read singleplayer save" << std::endl;
+        return 1;
+    }
+
+    SingleSave sp;
+    sp.xp = spDoc["xp"].GetUint();
+    for (auto itr = spDoc["quests"].MemberBegin(); itr != spDoc["quests"].MemberEnd(); ++itr)
+        sp.quests[itr->name.GetString()] = itr->value.GetUint();
+    for (auto& e : spDoc["inventory"].GetArray())
+    {
+        CoopNet::ItemSnap it{e["itemId"].GetUint(), static_cast<uint16_t>(e["qty"].GetUint())};
+        sp.inventory.push_back(it);
+    }
+
+    Document merged;
+    std::string summary;
+    MergeSaves(coopDoc, sp, merged, summary);
+    SaveJson("merged.dat", merged);
+    std::cout << summary;
+    return 0;
+}

--- a/cp2077-coop/ui/healthbar.inkwidget
+++ b/cp2077-coop/ui/healthbar.inkwidget
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inkCanvas>
+    <inkRectangle name="hp" size="200,6" position="0,0" color="#00FF00"/>
+    <inkRectangle name="armor" size="200,6" position="0,8" color="#3F80FF"/>
+</inkCanvas>

--- a/cp2077-coop/ui/ico_hex_cell.inkwidget
+++ b/cp2077-coop/ui/ico_hex_cell.inkwidget
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inkCanvas size="24,28">
+    <inkBorder name="bg" size="24,28" texture="hex_placeholder"/> 
+    <inkTextWidget name="code" text="00" anchor="0.5,0.5" hAlign="Center" vAlign="Center"/>
+</inkCanvas>

--- a/futureIdeas.md
+++ b/futureIdeas.md
@@ -1,0 +1,24 @@
+# Future Ideas
+
+The following tasks are referenced in code comments for later implementation:
+
+- **PHYS-3**: integrate vehicle rotation and force simulation.
+- **NR-2**: deterministic AI walk routine for NPCs.
+- **VD-3**: refine vehicle deceleration formula for ejection.
+- **PHYS-4**: use actual input vectors in prediction.
+- **CC-1**: seek camera to startTimeMs when cutscenes start.
+- **CC-3**: validate dialog choices via ConversationStateMachine.
+- **NR-3**: update NPC animation state handling.
+- **SA-1**: hide HUD layers while in spectator mode.
+- **P7-2**: announce DM winner and implement scoreboard UI.
+- **P7-1**: allow console to set DM mode.
+- **P3-4**: full chat overlay integration and message relays.
+- **SL-1**: derive sector from spawn position.
+- **NR-1**: parse avatar spawn/despawn payloads.
+- **NT-2**: track connection activity time.
+- **NT-3**: obtain relay bandwidth from libjuice.
+- **UI-4**: show coop settings panel.
+- **UI-2**: verify player system API for CoopMap icons.
+- **PP-1**: populate party data from lobby and derive session ID.
+- **NR-4**: add spatial partitioning for NPC interest checks.
+- **SA-3**: show real ping on the web dashboard.


### PR DESCRIPTION
### Ticket
Prompt 9-D · Economy & Duplication Lock-down

### Summary
* Added server-side `LedgerService` ensuring each transaction uses a nonce and fails if funds are insufficient or a replay occurs.
* Extended vendor controller to process purchase requests, debit the player via the ledger, create the item, and broadcast updated stock.
* Introduced `PurchaseRequest`/`PurchaseResult` packets with client helpers and inventory handlers.
* Connections now track a money balance and last processed nonce.

### Files Touched
- `cp2077-coop/src/net/Packets.hpp` (+24)
- `cp2077-coop/src/net/Net.hpp` (+1)
- `cp2077-coop/src/net/Net.cpp` (+11)
- `cp2077-coop/src/net/Connection.cpp` (+23)
- `cp2077-coop/src/net/Connection.hpp` (+2)
- `cp2077-coop/src/runtime/Inventory.reds` (+15)
- `cp2077-coop/src/server/InventoryController.cpp` (+13)
- `cp2077-coop/src/server/InventoryController.hpp` (+1)
- `cp2077-coop/src/server/VendorController.cpp` (+44)
- `cp2077-coop/src/server/VendorController.hpp` (+2)
- `cp2077-coop/src/server/LedgerService.cpp` (new, +40)
- `cp2077-coop/src/server/LedgerService.hpp` (new, +8)
- `cp2077-coop/CMakeLists.txt` (+1)

### Testing Performed
- `pre-commit` on affected files


------
https://chatgpt.com/codex/tasks/task_e_685b0e747b9083308bcde72190347790