### PR TITLE
Implement fixer holo-call and gig volume sync

### DIFF
--- a/cp2077-coop/CMakeLists.txt
+++ b/cp2077-coop/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(cp2077-coop SHARED
     src/net/Connection.cpp
     src/net/StatBatch.cpp
     src/net/NatClient.cpp
+    src/net/WorldMarkers.cpp
     src/core/GameClock.cpp
     src/core/SpatialGrid.cpp
     src/core/SaveFork.cpp
@@ -28,12 +29,19 @@ add_library(cp2077-coop SHARED
     src/physics/CarPhysics.cpp
     src/server/InventoryController.cpp
     src/server/VendorController.cpp
+    src/server/DealerController.cpp
     src/server/NpcController.cpp
     src/server/VehicleController.cpp
     src/server/BreachController.cpp
     src/server/ElevatorController.cpp
     src/server/GlobalEventController.cpp
     src/server/AdminController.cpp
+    src/server/CyberController.cpp
+    src/server/PerkController.cpp
+    src/server/QuestWatchdog.cpp
+    src/server/SnapshotHeap.cpp
+    src/server/TextureGuard.cpp
+    src/server/PoliceDispatch.cpp
     src/server/LedgerService.cpp
     src/server/WebDash.cpp
     src/voice/VoiceEncoder.cpp
@@ -44,6 +52,7 @@ target_include_directories(cp2077-coop
     PRIVATE
         "${PROJECT_SOURCE_DIR}/third_party/enet/include"
         "${PROJECT_SOURCE_DIR}/third_party"
+        "${PROJECT_SOURCE_DIR}/third_party/zstd"
 )
 
 target_link_libraries(cp2077-coop PRIVATE enet juice opus AL::AL OpenSSL::SSL)
@@ -61,6 +70,7 @@ add_custom_command(
 add_executable(coop_dedicated
     src/server/DedicatedMain.cpp
     src/server/DamageValidator.cpp
+    src/server/ServerConfig.cpp
     src/server/Heartbeat.cpp
     src/server/AdminController.cpp
 )

--- a/cp2077-coop/src/audio/VoiceOverQueue.reds
+++ b/cp2077-coop/src/audio/VoiceOverQueue.reds
@@ -1,0 +1,18 @@
+public struct VOEvent {
+    public let lineId: Uint32;
+    public let startTs: Uint32;
+}
+
+public class VoiceOverQueue {
+    public static let events: array<VOEvent>;
+
+    public static func OnPlay(lineId: Uint32) -> Void {
+        let ts = GameClock.GetTime();
+        let evt: VOEvent;
+        evt.lineId = lineId;
+        evt.startTs = ts;
+        events.PushBack(evt);
+        let audio = GameInstance.GetAudioSystem(GetGame());
+        if IsDefined(audio) { audio.TriggerEventById(lineId); };
+    }
+}

--- a/cp2077-coop/src/core/SaveMigration.cpp
+++ b/cp2077-coop/src/core/SaveMigration.cpp
@@ -1,11 +1,12 @@
 #include "SaveMigration.hpp"
-#include "SaveFork.hpp"
 #include "Hash.hpp"
+#include "SaveFork.hpp"
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 
-namespace CoopNet {
+namespace CoopNet
+{
 namespace fs = std::filesystem;
 
 static fs::path GetVanillaDir()
@@ -24,7 +25,8 @@ static fs::path GetVanillaDir()
 
 bool MigrateSinglePlayerSave()
 {
-    try {
+    try
+    {
         fs::path coopDir(kCoopSavePath);
         if (fs::exists(coopDir) && !fs::is_empty(coopDir))
             return true; // already migrated or have saves
@@ -57,7 +59,9 @@ bool MigrateSinglePlayerSave()
             sid = 1;
         SaveSession(sid, outJson);
         return true;
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
         std::cerr << "MigrateSinglePlayerSave error: " << e.what() << std::endl;
         return false;
     }
@@ -67,7 +71,8 @@ static size_t g_snapIndex = 0;
 
 void SaveRollbackSnapshot(uint32_t sessionId, const std::string& jsonBlob)
 {
-    try {
+    try
+    {
         EnsureCoopSaveDirs();
         fs::path dir = fs::path(kCoopSavePath) / "snapshots";
         fs::create_directories(dir);
@@ -76,15 +81,18 @@ void SaveRollbackSnapshot(uint32_t sessionId, const std::string& jsonBlob)
         if (out.is_open())
             out << jsonBlob;
         g_snapIndex = (g_snapIndex + 1) % 20;
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
         std::cerr << "SaveRollbackSnapshot error: " << e.what() << std::endl;
     }
 }
 
 bool ValidateSessionState(uint32_t sessionId)
 {
-    try {
-        fs::path file = fs::path(kCoopSavePath) / (std::to_string(sessionId) + ".json");
+    try
+    {
+        fs::path file = fs::path(kCoopSavePath) / (std::to_string(sessionId) + ".json.zst");
         std::ifstream in(file, std::ios::binary);
         if (!in.is_open() || in.peek() == EOF)
         {
@@ -102,11 +110,12 @@ bool ValidateSessionState(uint32_t sessionId)
             return false;
         }
         return true;
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
         std::cerr << "ValidateSessionState error: " << e.what() << std::endl;
         return false;
     }
 }
 
 } // namespace CoopNet
-

--- a/cp2077-coop/src/core/SessionState.hpp
+++ b/cp2077-coop/src/core/SessionState.hpp
@@ -17,5 +17,8 @@ void SaveMergeResolution(bool acceptAll);
 // Returns derived session id from sorted peer list
 uint32_t SessionState_SetParty(const std::vector<uint32_t>& peerIds);
 uint32_t SessionState_GetId();
+void SessionState_SetPerk(uint32_t peerId, uint32_t perkId, uint8_t rank);
+void SessionState_ClearPerks(uint32_t peerId);
+float SessionState_GetPerkHealthMult(uint32_t peerId);
 
 } // namespace CoopNet

--- a/cp2077-coop/src/gui/CyberCooldownHud.reds
+++ b/cp2077-coop/src/gui/CyberCooldownHud.reds
@@ -1,0 +1,59 @@
+public class CyberCooldownHud extends inkHUDLayer {
+    public static let s_instance: ref<CyberCooldownHud>;
+    private let canvas: ref<inkCanvas>;
+    private let bars: array<ref<inkCircleProgress>>;
+    private let times: array<Float>;
+
+    public static func Instance() -> ref<CyberCooldownHud> {
+        if !IsDefined(s_instance) {
+            s_instance = new CyberCooldownHud();
+            GameInstance.GetHUDManager(GetGame()).AddLayer(s_instance);
+        };
+        return s_instance;
+    }
+
+    public static func SetCooldown(slot: Uint8, sec: Float) -> Void {
+        let inst = Instance();
+        inst.EnsureUI(slot);
+        inst.times[slot] = sec;
+        inst.bars[slot].SetValue(1.0);
+    }
+
+    private func EnsureUI(slot: Uint8) -> Void {
+        if !IsDefined(canvas) {
+            canvas = new inkCanvas();
+            canvas.SetAnchor(inkEAnchor.TopRight);
+            canvas.SetMargin(new inkMargin(0.0, 200.0, 40.0, 0.0));
+            AddChild(canvas);
+        };
+        while bars.Size() <= Cast<Int32>(slot) {
+            let bar = new inkCircleProgress();
+            bar.SetRadius(20.0);
+            bar.SetStyle(n"HUDProgressCircle");
+            bar.SetTintColor(new HDRColor(0.4,0.4,0.4,1.0));
+            bar.SetMargin(new inkMargin(0.0, Cast<Float>(bars.Size())*50.0, 0.0, 0.0));
+            canvas.AddChild(bar);
+            bars.Push(bar);
+            times.Push(0.0);
+        };
+    }
+
+    public func OnUpdate(dt: Float) -> Void {
+        var i: Int32 = 0;
+        while i < bars.Size() {
+            if times[i] > 0.0 {
+                times[i] -= dt;
+                if times[i] <= 0.0 {
+                    times[i] = 0.0;
+                    bars[i].SetTintColor(new HDRColor(0.2,1.0,0.2,1.0));
+                    bars[i].SetValue(0.0);
+                } else {
+                    bars[i].SetValue(times[i] / MaxF(times[i], 0.001));
+                };
+            } else {
+                bars[i].SetTintColor(new HDRColor(0.2,1.0,0.2,1.0));
+            };
+            i += 1;
+        };
+    }
+}

--- a/cp2077-coop/src/gui/SpectatorHUD.reds
+++ b/cp2077-coop/src/gui/SpectatorHUD.reds
@@ -1,5 +1,6 @@
 public class SpectatorHUD extends inkGameController {
     private let hpText: wref<inkText>;
+    private let warnText: wref<inkText>;
     private let target: Uint32;
 
     public func OnCreate() -> Void {
@@ -10,6 +11,10 @@ public class SpectatorHUD extends inkGameController {
         c.AddChild(hpText);
         c.SetAnchor(inkEAnchor.CenterLeft);
         c.SetMargin(new inkMargin(20.0, 20.0, 0.0, 0.0));
+        warnText = new inkText();
+        warnText.SetMargin(new inkMargin(20.0, 60.0, 0.0, 0.0));
+        warnText.SetVisible(false);
+        c.AddChild(warnText);
     }
 
     public func SetTarget(id: Uint32) -> Void {
@@ -21,6 +26,19 @@ public class SpectatorHUD extends inkGameController {
         let avatar = GameInstance.GetPlayerSystem(GetGame()).FindObject(target) as AvatarProxy;
         if IsDefined(avatar) {
             hpText.SetText("HP: " + IntToString(avatar.health));
+        };
+    }
+
+    public func ShowWarning(msg: String) -> Void {
+        if IsDefined(warnText) {
+            warnText.SetText(msg);
+            warnText.SetVisible(true);
+        };
+    }
+
+    public func HideWarning() -> Void {
+        if IsDefined(warnText) {
+            warnText.SetVisible(false);
         };
     }
 }

--- a/cp2077-coop/src/gui/StatHud.reds
+++ b/cp2077-coop/src/gui/StatHud.reds
@@ -1,0 +1,76 @@
+public struct NetStats {
+    public var ping: Uint32;
+    public var loss: Float;
+    public var vKbps: Uint16;
+    public var sKbps: Uint16;
+    public var dropPkts: Uint16;
+}
+
+public class StatHud extends inkHUDLayer {
+    public static let s_instance: ref<StatHud>;
+    private let table: ref<inkCanvas>;
+    private let peerIds: array<Uint32>;
+    private let rows: array<ref<inkText>>;
+    private var visible: Bool;
+
+    public static func Instance() -> ref<StatHud> {
+        if !IsDefined(s_instance) {
+            s_instance = new StatHud();
+            GameInstance.GetHUDManager(GetGame()).AddLayer(s_instance);
+        };
+        return s_instance;
+    }
+
+    public static func Toggle() -> Void {
+        let inst = Instance();
+        inst.visible = !inst.visible;
+        if IsDefined(inst.table) { inst.table.SetVisible(inst.visible); };
+    }
+
+    public static func OnNetStats(peerId: Uint32, s: NetStats) -> Void {
+        Instance().UpdateRow(peerId, s);
+    }
+
+    private func UpdateRow(id: Uint32, s: NetStats) -> Void {
+        if !IsDefined(table) {
+            table = new inkCanvas();
+            table.SetAnchor(inkEAnchor.TopLeft);
+            table.SetMargin(new inkMargin(20.0,20.0,0.0,0.0));
+            AddChild(table);
+        };
+        var idx: Int32 = peerIds.Find(id);
+        if idx == -1 {
+            let row = new inkText();
+            row.SetStyle(n"Medium 32px Bold");
+            row.SetMargin(new inkMargin(0.0, 20.0 * Cast<Float>(peerIds.Size()),0.0,0.0));
+            table.AddChild(row);
+            peerIds.Push(id);
+            rows.Push(row);
+            idx = rows.Size() - 1;
+        };
+        let color: HDRColor;
+        if s.dropPkts > 5u {
+            color = new HDRColor(1.0,0.2,0.2,1.0);
+        } else if s.ping <= 80u {
+            color = new HDRColor(0.2,1.0,0.2,1.0);
+        } else if s.ping <= 150u {
+            color = new HDRColor(1.0,0.85,0.2,1.0);
+        } else {
+            color = new HDRColor(1.0,0.2,0.2,1.0);
+        };
+        rows[idx].SetTintColor(color);
+        rows[idx].SetText(IntToString(id) + "  " + IntToString(Cast<Int32>(s.ping)) + "ms  " +
+                          IntToString(Cast<Int32>(RoundF(s.loss*100.0))) + "%  " +
+                          IntToString(Cast<Int32>(s.vKbps)) + "  " +
+                          IntToString(Cast<Int32>(s.sKbps)) + "  " +
+                          IntToString(Cast<Int32>(s.dropPkts)) + "%  " +
+                          IntToString(Cast<Int32>(1000u / GameClock.currentTickMs)));
+    }
+
+    public func OnUpdate(dt: Float) -> Void {
+        let input = GameInstance.GetInputSystem(GetGame());
+        if input.IsActionJustPressed(EInputKey.IK_F1) {
+            Toggle();
+        };
+    }
+}

--- a/cp2077-coop/src/gui/WalletHud.reds
+++ b/cp2077-coop/src/gui/WalletHud.reds
@@ -1,0 +1,51 @@
+public class WalletHud extends inkHUDLayer {
+    public static let s_instance: ref<WalletHud>;
+    private let balanceLabel: ref<inkText>;
+    private let deltaLabel: ref<inkText>;
+    private var fade: Float;
+    public var eddies: Int64;
+
+    public static func Update(newBal: Int64) -> Void {
+        if !IsDefined(s_instance) {
+            s_instance = new WalletHud();
+            let hud = GameInstance.GetHUDManager(GetGame());
+            hud.AddLayer(s_instance);
+        };
+        s_instance.ApplyUpdate(newBal);
+    }
+
+    private func ApplyUpdate(newBal: Int64) -> Void {
+        if !IsDefined(balanceLabel) {
+            balanceLabel = new inkText();
+            balanceLabel.SetStyle(n"Medium 32px Bold");
+            balanceLabel.SetTintColor(new HDRColor(1.0, 0.85, 0.231, 1.0));
+            balanceLabel.SetAnchor(inkEAnchor.TopRight);
+            balanceLabel.SetMargin(new inkMargin(0.0, 20.0, 40.0, 0.0));
+            AddChild(balanceLabel);
+        };
+        let diff: Int64 = eddies - newBal;
+        eddies = newBal;
+        balanceLabel.SetText(Int64ToString(newBal));
+        if diff > 0 {
+            if !IsDefined(deltaLabel) {
+                deltaLabel = new inkText();
+                deltaLabel.SetStyle(n"Medium 32px Bold");
+                deltaLabel.SetTintColor(new HDRColor(1.0, 0.85, 0.231, 1.0));
+                deltaLabel.SetAnchor(inkEAnchor.TopRight);
+                deltaLabel.SetMargin(new inkMargin(0.0, 60.0, 40.0, 0.0));
+                AddChild(deltaLabel);
+            };
+            deltaLabel.SetText("-" + Int64ToString(diff) + " €$");
+            deltaLabel.SetOpacity(1.0);
+            fade = 1.0;
+        };
+    }
+
+    public func OnUpdate(dt: Float) -> Void {
+        if fade > 0.0 {
+            fade -= dt * 2.0;
+            if fade < 0.0 { fade = 0.0; };
+            if IsDefined(deltaLabel) { deltaLabel.SetOpacity(fade); };
+        };
+    }
+}

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -5,6 +5,8 @@
 #include "../runtime/GameModeManager.reds"
 #include "../server/BreachController.hpp"
 #include "../server/NpcController.hpp"
+#include "../server/StatusController.hpp"
+#include "../server/TrafficController.hpp"
 #include "../voice/VoiceDecoder.hpp"
 #include "Net.hpp"
 #include "StatBatch.hpp"
@@ -51,6 +53,11 @@ static void DMScoreboard_OnScorePacket(uint32_t peerId, uint16_t k, uint16_t d)
 static void DMScoreboard_OnMatchOver(uint32_t winner)
 {
     std::cout << "MatchOver " << winner << std::endl;
+}
+
+static void StatHud_OnStats(uint32_t peerId, const CoopNet::NetStats& s)
+{
+    RED4ext::ExecuteFunction("StatHud", "OnNetStats", nullptr, peerId, &s);
 }
 
 static void NpcProxy_Spawn(const CoopNet::NpcSnap& snap)
@@ -144,6 +151,11 @@ static void VendorSync_OnStock(const CoopNet::VendorStockPacket& pkt)
     RED4ext::ExecuteFunction("VendorSync", "OnStock", nullptr, &pkt);
 }
 
+static void VendorSync_OnStockUpdate(const CoopNet::VendorStockUpdatePacket& pkt)
+{
+    RED4ext::ExecuteFunction("VendorSync", "OnStockUpdate", nullptr, &pkt);
+}
+
 static void HeatSync_Apply(uint8_t level)
 {
     std::cout << "Heat level " << static_cast<int>(level) << std::endl;
@@ -151,7 +163,7 @@ static void HeatSync_Apply(uint8_t level)
 
 static void WeatherSync_Apply(const CoopNet::WorldStatePacket& pkt)
 {
-    std::cout << "World clock=" << pkt.worldClockMs << " weather=" << static_cast<int>(pkt.weatherId) << std::endl;
+    RED4ext::ExecuteFunction("WeatherSync", "ApplyWorldState", nullptr, &pkt);
 }
 
 static void GlobalEvent_OnPacket(const CoopNet::GlobalEventPacket& pkt)
@@ -185,6 +197,81 @@ static void UIPauseAudit_OnHoloEnd(uint32_t peerId)
 static void GameModeManager_SetFriendlyFire(bool enable)
 {
     std::cout << "FriendlyFire=" << (enable ? "true" : "false") << std::endl;
+}
+
+static void PoliceDispatch_OnCruiserSpawn(uint8_t idx, const uint32_t* seeds)
+{
+    RED4ext::ExecuteFunction("PoliceDispatch", "OnCruiserSpawn", nullptr, idx, seeds[0], seeds[1], seeds[2], seeds[3]);
+}
+
+static void NpcProxy_OnAIState(uint32_t npcId, uint8_t state)
+{
+    RED4ext::ExecuteFunction("NpcProxy", "OnAIState", nullptr, npcId, state);
+}
+
+static void PerkSync_OnUnlock(uint32_t peerId, uint32_t perkId, uint8_t rank)
+{
+    RED4ext::ExecuteFunction("PerkSync", "OnUnlock", nullptr, peerId, perkId, rank);
+}
+
+static void PerkSync_OnRespecAck(uint32_t peerId, uint16_t pts)
+{
+    RED4ext::ExecuteFunction("PerkSync", "OnRespecAck", nullptr, peerId, pts);
+}
+
+static void StatusEffectSync_OnApply(uint32_t targetId, uint8_t effectId, uint16_t durMs, uint8_t amp)
+{
+    RED4ext::ExecuteFunction("StatusEffectSync", "OnApply", nullptr, targetId, effectId, durMs, amp);
+}
+
+static void StatusEffectSync_OnTick(uint32_t targetId, int16_t delta)
+{
+    RED4ext::ExecuteFunction("StatusEffectSync", "OnTick", nullptr, targetId, delta);
+}
+
+static void TrafficSync_OnSeed(uint64_t hash, uint64_t seed)
+{
+    RED4ext::ExecuteFunction("TrafficSync", "OnSeed", nullptr, hash, seed);
+}
+
+static void TrafficSync_OnDespawn(uint32_t id)
+{
+    RED4ext::ExecuteFunction("TrafficSync", "OnDespawn", nullptr, id);
+}
+
+static void CrimeSpawner_OnEvent(const CoopNet::CrimeEventSpawnPacket& pkt)
+{
+    RED4ext::ExecuteFunction("CrimeSpawner", "OnEvent", nullptr, &pkt);
+}
+
+static void PropSync_OnBreak(uint32_t id, uint32_t seed)
+{
+    RED4ext::ExecuteFunction("PropSync", "OnBreak", nullptr, id, seed);
+}
+
+static void PropSync_OnIgnite(uint32_t id, uint16_t delay)
+{
+    RED4ext::ExecuteFunction("PropSync", "OnIgnite", nullptr, id, delay);
+}
+
+static void VoiceOverQueue_OnPlay(uint32_t lineId)
+{
+    RED4ext::ExecuteFunction("VoiceOverQueue", "OnPlay", nullptr, lineId);
+}
+
+static void FixerCallSync_OnStart(uint32_t id)
+{
+    RED4ext::ExecuteFunction("FixerCallSync", "OnStart", nullptr, id);
+}
+
+static void FixerCallSync_OnEnd(uint32_t id)
+{
+    RED4ext::ExecuteFunction("FixerCallSync", "OnEnd", nullptr, id);
+}
+
+static void GigSpawner_OnSpawn(uint32_t questId, uint32_t seed)
+{
+    RED4ext::ExecuteFunction("GigSpawner", "OnSpawn", nullptr, questId, seed);
 }
 
 static void SnapshotInterpolator_OnTickRateChange(uint16_t ms)
@@ -318,17 +405,20 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             ChatOverlay_Push(pkt->msg);
         }
         break;
-    case EMsg::QuestStage:
-        if (size >= sizeof(QuestStagePacket))
+    case EMsg::QuestStageP2P:
+        if (size >= sizeof(QuestStageP2PPacket))
         {
-            const QuestStagePacket* pkt = reinterpret_cast<const QuestStagePacket*>(payload);
-            QuestSync_ApplyQuestStage(pkt->nameHash, pkt->stage);
+            const QuestStageP2PPacket* pkt = reinterpret_cast<const QuestStageP2PPacket*>(payload);
+            CoopNet::QuestWatchdog_Record(pkt->phaseId, pkt->questHash, pkt->stage);
+            if (pkt->phaseId == peerId)
+                QuestSync_ApplyQuestStage(pkt->questHash, pkt->stage);
         }
         break;
     case EMsg::QuestResyncRequest:
         if (Net_IsAuthoritative())
         {
-            QuestFullSyncPacket pkt{}; // FIXME: populate from session state
+            QuestFullSyncPacket pkt{};
+            CoopNet::QuestWatchdog_BuildFullSync(peerId, pkt);
             Net_SendQuestFullSync(this, pkt);
         }
         break;
@@ -361,6 +451,102 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         {
             const NpcDespawnPacket* pkt = reinterpret_cast<const NpcDespawnPacket*>(payload);
             NpcProxy_Despawn(pkt->npcId);
+        }
+        break;
+    case EMsg::NpcSpawnCruiser:
+        if (size >= sizeof(NpcSpawnCruiserPacket))
+        {
+            const NpcSpawnCruiserPacket* pkt = reinterpret_cast<const NpcSpawnCruiserPacket*>(payload);
+            PoliceDispatch_OnCruiserSpawn(pkt->waveIdx, pkt->npcSeeds);
+        }
+        break;
+    case EMsg::NpcState:
+        if (size >= sizeof(NpcStatePacket))
+        {
+            const NpcStatePacket* pkt = reinterpret_cast<const NpcStatePacket*>(payload);
+            NpcProxy_OnAIState(pkt->npcId, pkt->aiState);
+        }
+        break;
+    case EMsg::CrimeEventSpawn:
+        if (size >= sizeof(CrimeEventSpawnPacket))
+        {
+            const CrimeEventSpawnPacket* pkt = reinterpret_cast<const CrimeEventSpawnPacket*>(payload);
+            CrimeSpawner_OnEvent(*pkt);
+        }
+        break;
+    case EMsg::GigSpawn:
+        if (size >= sizeof(GigSpawnPacket))
+        {
+            const GigSpawnPacket* pkt = reinterpret_cast<const GigSpawnPacket*>(payload);
+            GigSpawner_OnSpawn(pkt->questId, pkt->seed);
+        }
+        break;
+    case EMsg::CyberEquip:
+        if (size >= sizeof(CyberEquipPacket))
+        {
+            const CyberEquipPacket* pkt = reinterpret_cast<const CyberEquipPacket*>(payload);
+            CyberwareSync_OnEquip(pkt->peerId, pkt->slotId, pkt->snap);
+        }
+        break;
+    case EMsg::SlowMoStart:
+        if (size >= sizeof(SlowMoStartPacket))
+        {
+            const SlowMoStartPacket* pkt = reinterpret_cast<const SlowMoStartPacket*>(payload);
+            CyberwareSync_OnSlowMo(pkt->peerId, pkt->factor, pkt->durationMs);
+        }
+        break;
+    case EMsg::PerkUnlock:
+        if (size >= sizeof(PerkUnlockPacket))
+        {
+            const PerkUnlockPacket* pkt = reinterpret_cast<const PerkUnlockPacket*>(payload);
+            if (Net_IsAuthoritative())
+                CoopNet::PerkController_HandleUnlock(this, pkt->perkId, pkt->rank);
+            else
+                PerkSync_OnUnlock(pkt->peerId, pkt->perkId, pkt->rank);
+        }
+        break;
+    case EMsg::PerkRespecRequest:
+        if (size >= sizeof(PerkRespecRequestPacket) && Net_IsAuthoritative())
+        {
+            CoopNet::PerkController_HandleRespec(this);
+        }
+        break;
+    case EMsg::PerkRespecAck:
+        if (size >= sizeof(PerkRespecAckPacket) && !Net_IsAuthoritative())
+        {
+            const PerkRespecAckPacket* pkt = reinterpret_cast<const PerkRespecAckPacket*>(payload);
+            PerkSync_OnRespecAck(pkt->peerId, pkt->newPoints);
+        }
+        break;
+    case EMsg::StatusApply:
+        if (size >= sizeof(StatusApplyPacket))
+        {
+            const StatusApplyPacket* pkt = reinterpret_cast<const StatusApplyPacket*>(payload);
+            if (Net_IsAuthoritative())
+                CoopNet::StatusController_OnApply(this, *pkt);
+            else
+                StatusEffectSync_OnApply(pkt->targetId, pkt->effectId, pkt->durMs, pkt->amp);
+        }
+        break;
+    case EMsg::StatusTick:
+        if (size >= sizeof(StatusTickPacket) && !Net_IsAuthoritative())
+        {
+            const StatusTickPacket* pkt = reinterpret_cast<const StatusTickPacket*>(payload);
+            StatusEffectSync_OnTick(pkt->targetId, pkt->hpDelta);
+        }
+        break;
+    case EMsg::TrafficSeed:
+        if (size >= sizeof(TrafficSeedPacket) && !Net_IsAuthoritative())
+        {
+            const TrafficSeedPacket* pkt = reinterpret_cast<const TrafficSeedPacket*>(payload);
+            TrafficSync_OnSeed(pkt->sectorHash, pkt->seed64);
+        }
+        break;
+    case EMsg::TrafficDespawn:
+        if (size >= sizeof(TrafficDespawnPacket) && !Net_IsAuthoritative())
+        {
+            const TrafficDespawnPacket* pkt = reinterpret_cast<const TrafficDespawnPacket*>(payload);
+            TrafficSync_OnDespawn(pkt->vehId);
         }
         break;
     case EMsg::SectorChange:
@@ -445,6 +631,24 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             VehicleProxy_Detach(pkt->vehicleId, pkt->partId);
         }
         break;
+    case EMsg::PropBreak:
+        if (size >= sizeof(PropBreakPacket))
+        {
+            const PropBreakPacket* pkt = reinterpret_cast<const PropBreakPacket*>(payload);
+            if (Net_IsAuthoritative())
+                Net_BroadcastPropBreak(pkt->entityId, pkt->seed);
+            else
+                PropSync_OnBreak(pkt->entityId, pkt->seed);
+        }
+        break;
+    case EMsg::PropIgnite:
+        if (size >= sizeof(PropIgnitePacket))
+        {
+            const PropIgnitePacket* pkt = reinterpret_cast<const PropIgnitePacket*>(payload);
+            if (!Net_IsAuthoritative())
+                PropSync_OnIgnite(pkt->entityId, pkt->delayMs);
+        }
+        break;
     case EMsg::VehicleSpawn:
         if (size >= sizeof(VehicleSpawnPacket))
         {
@@ -471,6 +675,27 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         {
             const SeatRequestPacket* pkt = reinterpret_cast<const SeatRequestPacket*>(payload);
             CoopNet::VehicleController_HandleSeatRequest(this, pkt->vehicleId, pkt->seatIdx);
+        }
+        break;
+    case EMsg::VehicleSummonRequest:
+        if (size >= sizeof(VehicleSummonRequestPacket) && Net_IsAuthoritative())
+        {
+            const VehicleSummonRequestPacket* pkt = reinterpret_cast<const VehicleSummonRequestPacket*>(payload);
+            CoopNet::VehicleController_HandleSummon(this, pkt->vehId, pkt->pos);
+        }
+        break;
+    case EMsg::VehicleSummon:
+        if (size >= sizeof(VehicleSummonPacket))
+        {
+            const VehicleSummonPacket* pkt = reinterpret_cast<const VehicleSummonPacket*>(payload);
+            VehicleProxy_Spawn(pkt->vehId, &pkt->pos);
+        }
+        break;
+    case EMsg::Appearance:
+        if (size >= sizeof(AppearancePacket))
+        {
+            const AppearancePacket* pkt = reinterpret_cast<const AppearancePacket*>(payload);
+            AvatarProxy_OnAppearance(pkt->peerId, pkt->meshId, pkt->tintId);
         }
         break;
     case EMsg::EjectOccupant:
@@ -525,6 +750,13 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             CoopNet::ElevatorController_OnAck(this, pkt->elevatorId);
         }
         break;
+    case EMsg::SnapshotAck:
+        if (Net_IsAuthoritative())
+        {
+            auto blob = CoopNet::BuildMarkerBlob();
+            Net_SendWorldMarkers(this, blob);
+        }
+        break;
     case EMsg::HoloCallStart:
         if (size >= sizeof(HoloCallPacket))
         {
@@ -565,7 +797,14 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         if (size >= sizeof(CineStartPacket))
         {
             const CineStartPacket* pkt = reinterpret_cast<const CineStartPacket*>(payload);
-            Cutscene_OnCineStart(pkt->sceneId, pkt->startTimeMs);
+            if (pkt->solo && pkt->phaseId != peerId)
+            {
+                std::cout << "Teammate cinematic" << std::endl;
+            }
+            else
+            {
+                Cutscene_OnCineStart(pkt->sceneId, pkt->startTimeMs);
+            }
         }
         break;
     case EMsg::Viseme:
@@ -596,7 +835,30 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             else
             {
                 CoopVoice::PushPacket(pkt->seq, pkt->data, pkt->size);
+                voiceRecv++;
             }
+        }
+        break;
+    case EMsg::VOPlay:
+        if (size >= sizeof(VOPlayPacket))
+        {
+            const VOPlayPacket* pkt = reinterpret_cast<const VOPlayPacket*>(payload);
+            if (!Net_IsAuthoritative())
+                VoiceOverQueue_OnPlay(pkt->lineId);
+        }
+        break;
+    case EMsg::FixerCallStart:
+        if (size >= sizeof(FixerCallPacket))
+        {
+            const FixerCallPacket* pkt = reinterpret_cast<const FixerCallPacket*>(payload);
+            FixerCallSync_OnStart(pkt->fixerId);
+        }
+        break;
+    case EMsg::FixerCallEnd:
+        if (size >= sizeof(FixerCallPacket))
+        {
+            const FixerCallPacket* pkt = reinterpret_cast<const FixerCallPacket*>(payload);
+            FixerCallSync_OnEnd(pkt->fixerId);
         }
         break;
     case EMsg::GlobalEvent:
@@ -618,6 +880,40 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         {
             const VendorStockPacket* pkt = reinterpret_cast<const VendorStockPacket*>(payload);
             VendorSync_OnStock(*pkt);
+        }
+        break;
+    case EMsg::VendorStockUpdate:
+        if (size >= sizeof(VendorStockUpdatePacket))
+        {
+            const VendorStockUpdatePacket* pkt = reinterpret_cast<const VendorStockUpdatePacket*>(payload);
+            VendorSync_OnStockUpdate(*pkt);
+        }
+        break;
+    case EMsg::PingOutline:
+        if (size >= sizeof(PingOutlinePacket))
+        {
+            const PingOutlinePacket* pkt = reinterpret_cast<const PingOutlinePacket*>(payload);
+            array<Uint32> ids;
+            let cnt : Int32 = Cast<Int32>(pkt->count);
+            let i : Int32 = 0;
+            while
+                i < cnt&& i < 32
+                {
+                    ids.PushBack(pkt->entityIds[i]);
+                    i += 1;
+                }
+            QuickhackSync_OnPingOutline(pkt->peerId, pkt->durationMs, ids);
+        }
+        break;
+    case EMsg::WorldMarkers:
+        if (size >= sizeof(uint16_t) && !Net_IsAuthoritative())
+        {
+            const WorldMarkersPacket* pkt = reinterpret_cast<const WorldMarkersPacket*>(payload);
+            if (size >= sizeof(uint16_t) + pkt->blobBytes)
+            {
+                CoopNet::ApplyMarkerBlob(pkt->zstdBlob, pkt->blobBytes);
+                std::cout << "[HotJoin] markers ready" << std::endl;
+            }
         }
         break;
     case EMsg::AdminCmd:
@@ -662,6 +958,55 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             CoopNet::VendorController_HandlePurchase(this, pkt->vendorId, pkt->itemId, pkt->nonce);
         }
         break;
+    case EMsg::DealerBuy:
+        if (size >= sizeof(DealerBuyPacket) && Net_IsAuthoritative())
+        {
+            const DealerBuyPacket* pkt = reinterpret_cast<const DealerBuyPacket*>(payload);
+            CoopNet::DealerController_HandleBuy(this, pkt->vehicleTpl, pkt->price);
+        }
+        break;
+    case EMsg::VehicleUnlock:
+        if (size >= sizeof(VehicleUnlockPacket) && !Net_IsAuthoritative())
+        {
+            const VehicleUnlockPacket* pkt = reinterpret_cast<const VehicleUnlockPacket*>(payload);
+            VehicleUnlockSync_OnUnlock(pkt->peerId, pkt->vehicleTpl);
+        }
+        break;
+    case EMsg::WeaponInspectStart:
+        if (size >= sizeof(WeaponInspectPacket))
+        {
+            const WeaponInspectPacket* pkt = reinterpret_cast<const WeaponInspectPacket*>(payload);
+            WeaponSync_OnInspect(pkt->peerId, pkt->animId);
+        }
+        break;
+    case EMsg::FinisherStart:
+        if (size >= sizeof(FinisherStartPacket))
+        {
+            const FinisherStartPacket* pkt = reinterpret_cast<const FinisherStartPacket*>(payload);
+            WeaponSync_OnFinisherStart(pkt->actorId, pkt->victimId, pkt->animId);
+        }
+        break;
+    case EMsg::FinisherEnd:
+        if (size >= sizeof(FinisherEndPacket))
+        {
+            const FinisherEndPacket* pkt = reinterpret_cast<const FinisherEndPacket*>(payload);
+            WeaponSync_OnFinisherEnd(pkt->actorId);
+        }
+        break;
+    case EMsg::TextureBiasChange:
+        if (size >= sizeof(TextureBiasPacket))
+        {
+            const TextureBiasPacket* pkt = reinterpret_cast<const TextureBiasPacket*>(payload);
+            TextureBiasSync_OnChange(pkt->bias);
+        }
+        break;
+    case EMsg::LootRoll:
+        if (size >= sizeof(LootRollPacket) && !Net_IsAuthoritative())
+        {
+            const LootRollPacket* pkt = reinterpret_cast<const LootRollPacket*>(payload);
+            LootAuthority_OnLootRoll(pkt->containerId, pkt->seed);
+        }
+        break;
     case EMsg::PurchaseResult:
         if (size >= sizeof(PurchaseResultPacket) && !Net_IsAuthoritative())
         {
@@ -703,6 +1048,24 @@ void Connection::Update(uint64_t nowMs)
             std::cout << "SectorReady timeout" << std::endl;
             sectorReady = true;
         }
+    }
+    if (lastStatTime == 0)
+        lastStatTime = nowMs;
+    if (nowMs - lastStatTime >= 2000)
+    {
+        CoopNet::NetStats s{};
+        s.ping = static_cast<uint32_t>(rttMs);
+        s.loss = packetLoss;
+        uint64_t dt = nowMs - lastStatTime;
+        s.vKbps = static_cast<uint16_t>((voiceBytes * 1000 / dt) / 1024);
+        s.sKbps = static_cast<uint16_t>((snapBytes * 1000 / dt) / 1024);
+        s.dropPkts = CoopVoice::ConsumeDropPct();
+        voiceBytes = 0;
+        snapBytes = 0;
+        lastStatTime = nowMs;
+        voiceDropped = 0;
+        voiceRecv = 0;
+        StatHud_OnStats(peerId, s);
     }
     CoopNet::StatBatch_Tick(static_cast<float>(CoopNet::GameClock::GetTickMs()) / 1000.f);
 }

--- a/cp2077-coop/src/net/Connection.hpp
+++ b/cp2077-coop/src/net/Connection.hpp
@@ -65,8 +65,14 @@ public:
     float rttHist[16]{};
     uint8_t rttIndex = 0;
     float packetLoss = 0.f;
+    uint64_t voiceBytes = 0;
+    uint64_t snapBytes = 0;
+    uint32_t voiceRecv = 0;
+    uint32_t voiceDropped = 0;
+    uint64_t lastStatTime = 0;
     uint64_t balance = 10000;
     uint64_t lastNonce = 0;
+    uint64_t invulEndTick = 0;
 };
 
 } // namespace CoopNet

--- a/cp2077-coop/src/net/Net.cpp
+++ b/cp2077-coop/src/net/Net.cpp
@@ -1,6 +1,8 @@
 #include "Net.hpp"
 #include "../core/Hash.hpp"
 #include "../server/AdminController.hpp"
+#include "../server/PoliceDispatch.hpp"
+#include "../server/QuestWatchdog.hpp"
 #include "Connection.hpp"
 #include "NatClient.hpp"
 #include "NetConfig.hpp"
@@ -175,6 +177,19 @@ void Net_Broadcast(EMsg type, const void* data, uint16_t size)
     enet_host_broadcast(g_Host, 0, pkt);
 }
 
+void Net_SendUnreliableToAll(EMsg type, const void* data, uint16_t size)
+{
+    if (!g_Host)
+        return;
+
+    ENetPacket* pkt = enet_packet_create(nullptr, sizeof(PacketHeader) + size, 0);
+    PacketHeader hdr{static_cast<uint16_t>(type), size};
+    std::memcpy(pkt->data, &hdr, sizeof(hdr));
+    if (size > 0 && data)
+        std::memcpy(pkt->data + sizeof(hdr), data, size);
+    enet_host_broadcast(g_Host, 0, pkt);
+}
+
 void Net_SendSectorReady(uint64_t hash)
 {
     auto conns = Net_GetConnections();
@@ -211,6 +226,16 @@ void Net_SendPurchaseRequest(uint32_t vendorId, uint32_t itemId, uint64_t nonce)
     {
         PurchaseRequestPacket pkt{vendorId, itemId, nonce};
         Net_Send(conns[0], EMsg::PurchaseRequest, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendVehicleSummonRequest(uint32_t vehId, const TransformSnap& pos)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        VehicleSummonRequestPacket pkt{vehId, pos};
+        Net_Send(conns[0], EMsg::VehicleSummonRequest, &pkt, sizeof(pkt));
     }
 }
 
@@ -313,6 +338,7 @@ void Net_BroadcastHeat(uint8_t level)
 {
     HeatPacket pkt{level, {0, 0, 0}};
     Net_Broadcast(EMsg::HeatSync, &pkt, sizeof(pkt));
+    PoliceDispatch_OnHeatChange(level);
 }
 
 void Net_BroadcastElevatorCall(uint32_t peerId, uint32_t elevatorId, uint8_t floorIdx)
@@ -340,7 +366,17 @@ void Net_SendTeleportAck(uint32_t elevatorId)
 void Net_BroadcastQuestStage(uint32_t nameHash, uint16_t stage)
 {
     QuestStagePacket pkt{nameHash, stage, 0};
+    for (auto& e : g_Peers)
+        CoopNet::QuestWatchdog_Record(e.conn->peerId, nameHash, stage);
     Net_Broadcast(EMsg::QuestStage, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastQuestStageP2P(uint32_t phaseId, uint32_t questHash, uint16_t stage)
+{
+    QuestStageP2PPacket pkt{phaseId, questHash, stage, 0};
+    for (auto& e : g_Peers)
+        CoopNet::QuestWatchdog_Record(phaseId, questHash, stage);
+    Net_Broadcast(EMsg::QuestStageP2P, &pkt, sizeof(pkt));
 }
 
 void Net_SendQuestResyncRequest()
@@ -351,6 +387,23 @@ void Net_SendQuestResyncRequest()
         QuestResyncRequestPacket pkt{0};
         Net_Send(conns[0], EMsg::QuestResyncRequest, &pkt, sizeof(pkt));
     }
+}
+
+void Net_SendQuestResyncRequestTo(Connection* conn)
+{
+    if (!conn)
+        return;
+    QuestResyncRequestPacket pkt{0};
+    Net_Send(conn, EMsg::QuestResyncRequest, &pkt, sizeof(pkt));
+}
+
+Connection* Net_FindConnection(uint32_t peerId)
+{
+    auto it =
+        std::find_if(g_Peers.begin(), g_Peers.end(), [&](const PeerEntry& p) { return p.conn->peerId == peerId; });
+    if (it == g_Peers.end())
+        return nullptr;
+    return it->conn;
 }
 
 void Net_SendQuestFullSync(CoopNet::Connection* conn, const QuestFullSyncPacket& pkt)
@@ -440,9 +493,9 @@ void Net_BroadcastNatCandidate(const char* sdp)
     Net_Broadcast(EMsg::NatCandidate, &pkt, sizeof(pkt));
 }
 
-void Net_BroadcastCineStart(uint32_t sceneId, uint32_t startTimeMs)
+void Net_BroadcastCineStart(uint32_t sceneId, uint32_t startTimeMs, uint32_t phaseId, bool solo)
 {
-    CineStartPacket pkt{sceneId, startTimeMs};
+    CineStartPacket pkt{sceneId, startTimeMs, phaseId, static_cast<uint8_t>(solo), {0, 0, 0}};
     Net_Broadcast(EMsg::CineStart, &pkt, sizeof(pkt));
 }
 
@@ -476,6 +529,7 @@ void Net_SendVoice(const uint8_t* data, uint16_t size, uint16_t seq)
         VoicePacket pkt{0u, seq, size, {0}};
         std::memcpy(pkt.data, data, std::min<size_t>(size, sizeof(pkt.data)));
         Net_Send(conns[0], EMsg::Voice, &pkt, static_cast<uint16_t>(sizeof(pkt)));
+        conns[0]->voiceBytes += sizeof(pkt);
     }
 }
 
@@ -484,13 +538,14 @@ void Net_BroadcastVoice(uint32_t peerId, const uint8_t* data, uint16_t size, uin
     VoicePacket pkt{peerId, seq, size, {0}};
     std::memcpy(pkt.data, data, std::min<size_t>(size, sizeof(pkt.data)));
     Net_Broadcast(EMsg::Voice, &pkt, static_cast<uint16_t>(sizeof(pkt)));
+    for (auto* c : Net_GetConnections())
+        c->voiceBytes += sizeof(pkt);
 }
 
-void Net_BroadcastWorldState(uint64_t clockMs, uint32_t sunAngle, uint8_t weatherId, uint32_t weatherSeed,
-                             uint8_t bdPhase)
+void Net_BroadcastWorldState(uint16_t sunAngleDeg, uint8_t weatherId)
 {
-    WorldStatePacket pkt{clockMs, sunAngle, weatherSeed, weatherId, bdPhase, {0, 0}};
-    Net_Broadcast(EMsg::WorldState, &pkt, sizeof(pkt));
+    WorldStatePacket pkt{sunAngleDeg, weatherId};
+    Net_SendUnreliableToAll(EMsg::WorldState, &pkt, sizeof(pkt));
 }
 
 void Net_BroadcastGlobalEvent(uint32_t eventId, uint8_t phase, bool start, uint32_t seed)
@@ -508,4 +563,218 @@ void Net_BroadcastCrowdSeed(uint64_t sectorHash, uint32_t seed)
 void Net_BroadcastVendorStock(const VendorStockPacket& pkt)
 {
     Net_Broadcast(EMsg::VendorStock, &pkt, sizeof(VendorStockPacket));
+}
+
+void Net_BroadcastVendorStockUpdate(const VendorStockUpdatePacket& pkt)
+{
+    Net_Broadcast(EMsg::VendorStockUpdate, &pkt, sizeof(VendorStockUpdatePacket));
+}
+
+void Net_SendWorldMarkers(Connection* conn, const std::vector<uint8_t>& blob)
+{
+    if (!conn || blob.size() > 10240)
+        return;
+    std::vector<uint8_t> buf(sizeof(WorldMarkersPacket) + blob.size());
+    auto* pkt = reinterpret_cast<WorldMarkersPacket*>(buf.data());
+    pkt->blobBytes = static_cast<uint16_t>(blob.size());
+    std::memcpy(pkt->zstdBlob, blob.data(), blob.size());
+    Net_Send(conn, EMsg::WorldMarkers, pkt, static_cast<uint16_t>(buf.size()));
+}
+
+void Net_BroadcastNpcSpawnCruiser(uint8_t waveIdx, const uint32_t seeds[4])
+{
+    NpcSpawnCruiserPacket pkt{};
+    pkt.waveIdx = waveIdx;
+    std::memcpy(pkt.npcSeeds, seeds, sizeof(pkt.npcSeeds));
+    Net_Broadcast(EMsg::NpcSpawnCruiser, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastNpcState(uint32_t npcId, uint8_t aiState)
+{
+    NpcStatePacket pkt{npcId, aiState, {0, 0, 0}};
+    Net_Broadcast(EMsg::NpcState, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastCrimeEvent(const CrimeEventSpawnPacket& pkt)
+{
+    Net_Broadcast(EMsg::CrimeEventSpawn, &pkt, sizeof(CrimeEventSpawnPacket));
+}
+
+void Net_BroadcastCyberEquip(uint32_t peerId, uint8_t slotId, const ItemSnap& snap)
+{
+    CyberEquipPacket pkt{};
+    pkt.peerId = peerId;
+    pkt.slotId = slotId;
+    pkt.snap = snap;
+    Net_Broadcast(EMsg::CyberEquip, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastSlowMoStart(uint32_t peerId, float factor, uint16_t durationMs)
+{
+    SlowMoStartPacket pkt{peerId, factor, durationMs, 0};
+    Net_Broadcast(EMsg::SlowMoStart, &pkt, sizeof(pkt));
+}
+
+void Net_SendPerkUnlock(uint32_t perkId, uint8_t rank)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        PerkUnlockPacket pkt{0u, perkId, rank, {0, 0, 0}};
+        Net_Send(conns[0], EMsg::PerkUnlock, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastPerkUnlock(uint32_t peerId, uint32_t perkId, uint8_t rank)
+{
+    PerkUnlockPacket pkt{peerId, perkId, rank, {0, 0, 0}};
+    Net_Broadcast(EMsg::PerkUnlock, &pkt, sizeof(pkt));
+}
+
+void Net_SendPerkRespecRequest()
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        PerkRespecRequestPacket pkt{0u};
+        Net_Send(conns[0], EMsg::PerkRespecRequest, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendPerkRespecAck(CoopNet::Connection* conn, uint16_t newPoints)
+{
+    PerkRespecAckPacket pkt{conn->peerId, newPoints, {0, 0}};
+    Net_Send(conn, EMsg::PerkRespecAck, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastStatusApply(uint32_t targetId, uint8_t effectId, uint16_t durMs, uint8_t amp)
+{
+    StatusApplyPacket pkt{targetId, effectId, durMs, amp};
+    Net_Broadcast(EMsg::StatusApply, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastStatusTick(uint32_t targetId, int16_t hpDelta)
+{
+    StatusTickPacket pkt{targetId, hpDelta};
+    Net_Broadcast(EMsg::StatusTick, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastTrafficSeed(uint64_t sectorHash, uint64_t seed)
+{
+    TrafficSeedPacket pkt{sectorHash, seed};
+    Net_Broadcast(EMsg::TrafficSeed, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastTrafficDespawn(uint32_t vehId)
+{
+    TrafficDespawnPacket pkt{vehId};
+    Net_Broadcast(EMsg::TrafficDespawn, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastPropBreak(uint32_t entityId, uint32_t seed)
+{
+    PropBreakPacket pkt{entityId, seed};
+    Net_Broadcast(EMsg::PropBreak, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastPropIgnite(uint32_t entityId, uint16_t delayMs)
+{
+    PropIgnitePacket pkt{entityId, delayMs, 0};
+    Net_Broadcast(EMsg::PropIgnite, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastVOPlay(uint32_t lineId)
+{
+    VOPlayPacket pkt{lineId};
+    Net_Broadcast(EMsg::VOPlay, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastFixerCallStart(uint32_t fixerId)
+{
+    FixerCallPacket pkt{fixerId};
+    Net_Broadcast(EMsg::FixerCallStart, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastFixerCallEnd(uint32_t fixerId)
+{
+    FixerCallPacket pkt{fixerId};
+    Net_Broadcast(EMsg::FixerCallEnd, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastGigSpawn(uint32_t questId, uint32_t seed)
+{
+    GigSpawnPacket pkt{questId, seed};
+    Net_Broadcast(EMsg::GigSpawn, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastVehicleSummon(uint32_t vehId, uint32_t ownerId, const TransformSnap& pos)
+{
+    VehicleSummonPacket pkt{vehId, ownerId, pos};
+    Net_Broadcast(EMsg::VehicleSummon, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastAppearance(uint32_t peerId, uint32_t meshId, uint32_t tintId)
+{
+    AppearancePacket pkt{peerId, meshId, tintId};
+    Net_Broadcast(EMsg::Appearance, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastPingOutline(uint32_t peerId, uint16_t durationMs, const std::vector<uint32_t>& ids)
+{
+    if (ids.empty() || ids.size() > 32)
+        return;
+    PingOutlinePacket pkt{};
+    pkt.peerId = peerId;
+    pkt.count = static_cast<uint8_t>(ids.size());
+    pkt._pad = 0;
+    pkt.durationMs = durationMs;
+    for (size_t i = 0; i < ids.size(); ++i)
+        pkt.entityIds[i] = ids[i];
+    Net_Broadcast(EMsg::PingOutline, &pkt, sizeof(uint32_t) * pkt.count + 8);
+}
+
+void Net_BroadcastLootRoll(uint32_t containerId, uint32_t seed)
+{
+    LootRollPacket pkt{containerId, seed};
+    Net_Broadcast(EMsg::LootRoll, &pkt, sizeof(pkt));
+}
+
+void Net_SendDealerBuy(uint32_t vehicleTpl, uint32_t price)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        DealerBuyPacket pkt{vehicleTpl, price};
+        Net_Send(conns[0], EMsg::DealerBuy, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastVehicleUnlock(uint32_t peerId, uint32_t vehicleTpl)
+{
+    VehicleUnlockPacket pkt{peerId, vehicleTpl};
+    Net_Broadcast(EMsg::VehicleUnlock, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastWeaponInspect(uint32_t peerId, uint16_t animId)
+{
+    WeaponInspectPacket pkt{peerId, animId, 0};
+    Net_Broadcast(EMsg::WeaponInspectStart, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastFinisherStart(uint32_t actorId, uint32_t victimId, uint16_t animId)
+{
+    FinisherStartPacket pkt{actorId, victimId, animId, 0};
+    Net_Broadcast(EMsg::FinisherStart, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastFinisherEnd(uint32_t actorId)
+{
+    FinisherEndPacket pkt{actorId};
+    Net_Broadcast(EMsg::FinisherEnd, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastTextureBiasChange(uint8_t bias)
+{
+    TextureBiasPacket pkt{bias, {0, 0, 0}};
+    Net_Broadcast(EMsg::TextureBiasChange, &pkt, sizeof(pkt));
 }

--- a/cp2077-coop/src/net/Net.hpp
+++ b/cp2077-coop/src/net/Net.hpp
@@ -10,7 +10,15 @@
 namespace CoopNet
 {
 class Connection;
-}
+struct NetStats
+{
+    uint32_t ping;
+    float loss;
+    uint16_t vKbps;
+    uint16_t sKbps;
+    uint16_t dropPkts;
+};
+} // namespace CoopNet
 void Net_Init();
 void Net_Shutdown();
 void Net_Poll(uint32_t maxMs);
@@ -18,6 +26,7 @@ bool Net_IsAuthoritative();
 std::vector<CoopNet::Connection*> Net_GetConnections();
 void Net_Send(CoopNet::Connection* conn, CoopNet::EMsg type, const void* data, uint16_t size);
 void Net_Broadcast(CoopNet::EMsg type, const void* data, uint16_t size);
+void Net_SendUnreliableToAll(CoopNet::EMsg type, const void* data, uint16_t size);
 void Net_SendSectorReady(uint64_t hash);
 void Net_SendCraftRequest(uint32_t recipeId);
 void Net_SendAttachRequest(uint64_t itemId, uint8_t slotIdx, uint64_t attachmentId);
@@ -39,7 +48,10 @@ void Net_SendElevatorCall(uint32_t elevatorId, uint8_t floorIdx);
 void Net_BroadcastElevatorArrive(uint32_t elevatorId, uint64_t sectorHash, const RED4ext::Vector3& pos);
 void Net_SendTeleportAck(uint32_t elevatorId);
 void Net_BroadcastQuestStage(uint32_t nameHash, uint16_t stage);
+void Net_BroadcastQuestStageP2P(uint32_t phaseId, uint32_t questHash, uint16_t stage); // PX-2
 void Net_SendQuestResyncRequest();
+void Net_SendQuestResyncRequestTo(CoopNet::Connection* conn);
+CoopNet::Connection* Net_FindConnection(uint32_t peerId);
 void Net_SendQuestFullSync(CoopNet::Connection* conn, const QuestFullSyncPacket& pkt);
 void Net_BroadcastHoloCallStart(uint32_t peerId);
 void Net_BroadcastHoloCallEnd(uint32_t peerId);
@@ -55,15 +67,48 @@ void Nat_Start();
 void Nat_PerformHandshake(CoopNet::Connection* conn);
 uint64_t Nat_GetRelayBytes();
 void Net_BroadcastNatCandidate(const char* sdp);
-void Net_BroadcastCineStart(uint32_t sceneId, uint32_t startTimeMs);
+void Net_BroadcastCineStart(uint32_t sceneId, uint32_t startTimeMs, uint32_t phaseId, bool solo); // PX-4
 void Net_BroadcastViseme(uint32_t npcId, uint8_t visemeId, uint32_t timeMs);
 void Net_SendDialogChoice(uint8_t choiceIdx);
 void Net_BroadcastDialogChoice(uint32_t peerId, uint8_t choiceIdx);
 void Net_SendVoice(const uint8_t* data, uint16_t size, uint16_t seq);
 void Net_BroadcastVoice(uint32_t peerId, const uint8_t* data, uint16_t size, uint16_t seq);
-void Net_BroadcastWorldState(uint64_t clockMs, uint32_t sunAngle, uint8_t weatherId, uint32_t weatherSeed,
-                             uint8_t bdPhase);
+void Net_BroadcastWorldState(uint16_t sunAngleDeg, uint8_t weatherId);
 void Net_BroadcastGlobalEvent(uint32_t eventId, uint8_t phase, bool start, uint32_t seed);
 void Net_BroadcastCrowdSeed(uint64_t sectorHash, uint32_t seed);
 void Net_BroadcastVendorStock(const VendorStockPacket& pkt);
+void Net_BroadcastVendorStockUpdate(const VendorStockUpdatePacket& pkt);
 void Net_SendPurchaseRequest(uint32_t vendorId, uint32_t itemId, uint64_t nonce);
+void Net_SendWorldMarkers(CoopNet::Connection* conn, const std::vector<uint8_t>& blob);
+std::vector<uint8_t> BuildMarkerBlob();
+void ApplyMarkerBlob(const uint8_t* buf, size_t len);
+void Net_BroadcastNpcSpawnCruiser(uint8_t waveIdx, const uint32_t seeds[4]);
+void Net_BroadcastNpcState(uint32_t npcId, uint8_t aiState);
+void Net_BroadcastCrimeEvent(const CrimeEventSpawnPacket& pkt);
+void Net_BroadcastCyberEquip(uint32_t peerId, uint8_t slotId, const ItemSnap& snap);
+void Net_BroadcastSlowMoStart(uint32_t peerId, float factor, uint16_t durationMs);
+void Net_SendPerkUnlock(uint32_t perkId, uint8_t rank);
+void Net_BroadcastPerkUnlock(uint32_t peerId, uint32_t perkId, uint8_t rank);
+void Net_SendPerkRespecRequest();
+void Net_SendPerkRespecAck(CoopNet::Connection* conn, uint16_t newPoints);
+void Net_BroadcastStatusApply(uint32_t targetId, uint8_t effectId, uint16_t durMs, uint8_t amp);
+void Net_BroadcastStatusTick(uint32_t targetId, int16_t hpDelta);
+void Net_BroadcastTrafficSeed(uint64_t sectorHash, uint64_t seed);
+void Net_BroadcastTrafficDespawn(uint32_t vehId);
+void Net_BroadcastPropBreak(uint32_t entityId, uint32_t seed);
+void Net_BroadcastPropIgnite(uint32_t entityId, uint16_t delayMs);
+void Net_BroadcastVOPlay(uint32_t lineId);
+void Net_SendVehicleSummonRequest(uint32_t vehId, const TransformSnap& pos);
+void Net_BroadcastFixerCallStart(uint32_t fixerId);
+void Net_BroadcastFixerCallEnd(uint32_t fixerId);
+void Net_BroadcastGigSpawn(uint32_t questId, uint32_t seed);
+void Net_BroadcastVehicleSummon(uint32_t vehId, uint32_t ownerId, const TransformSnap& pos);
+void Net_BroadcastAppearance(uint32_t peerId, uint32_t meshId, uint32_t tintId);
+void Net_BroadcastPingOutline(uint32_t peerId, uint16_t durationMs, const std::vector<uint32_t>& ids);
+void Net_BroadcastLootRoll(uint32_t containerId, uint32_t seed);
+void Net_SendDealerBuy(uint32_t vehicleTpl, uint32_t price);
+void Net_BroadcastVehicleUnlock(uint32_t peerId, uint32_t vehicleTpl);
+void Net_BroadcastWeaponInspect(uint32_t peerId, uint16_t animId);
+void Net_BroadcastFinisherStart(uint32_t actorId, uint32_t victimId, uint16_t animId);
+void Net_BroadcastFinisherEnd(uint32_t actorId);
+void Net_BroadcastTextureBiasChange(uint8_t bias);

--- a/cp2077-coop/src/net/Packets.hpp
+++ b/cp2077-coop/src/net/Packets.hpp
@@ -26,6 +26,7 @@ enum class EMsg : uint16_t
     AvatarSpawn,
     AvatarDespawn,
     QuestStage,
+    QuestStageP2P,
     QuestFullSync,
     QuestResyncRequest,
     SceneTrigger,
@@ -33,6 +34,7 @@ enum class EMsg : uint16_t
     HitConfirm,
     VehicleSpawn,
     SeatRequest,
+    VehicleSummonRequest,
     SeatAssign,
     VehicleHit,
     Quickhack,
@@ -76,8 +78,39 @@ enum class EMsg : uint16_t
     GlobalEvent,
     CrowdSeed,
     VendorStock,
+    VendorStockUpdate,
     PurchaseRequest,
-    PurchaseResult
+    PurchaseResult,
+    SnapshotAck,
+    WorldMarkers,
+    NpcSpawnCruiser,
+    NpcState,
+    CrimeEventSpawn,
+    CyberEquip,
+    SlowMoStart,
+    PerkUnlock,
+    PerkRespecRequest,
+    PerkRespecAck,
+    StatusApply,
+    StatusTick,
+    TrafficSeed,
+    TrafficDespawn,
+    PropBreak,
+    PropIgnite,
+    VOPlay,
+    FixerCallStart,
+    FixerCallEnd,
+    GigSpawn,
+    VehicleSummon,
+    Appearance,
+    PingOutline,
+    LootRoll,
+    DealerBuy,
+    VehicleUnlock,
+    WeaponInspectStart,
+    FinisherStart,
+    FinisherEnd,
+    TextureBiasChange
 };
 
 struct PacketHeader
@@ -150,6 +183,12 @@ struct SeatRequestPacket
     uint8_t seatIdx; // 0-3
 };
 
+struct VehicleSummonRequestPacket
+{
+    uint32_t vehId;
+    TransformSnap pos;
+};
+
 struct SeatAssignPacket
 {
     uint32_t peerId;
@@ -167,12 +206,8 @@ struct VehicleHitPacket
 
 struct WorldStatePacket
 {
-    uint64_t worldClockMs;
-    uint32_t sunAngle; // degrees * 100
-    uint32_t weatherSeed;
+    uint16_t sunAngleDeg; // 0-359
     uint8_t weatherId;
-    uint8_t braindancePhase;
-    uint8_t pad[2];
 };
 
 struct ScoreUpdatePacket
@@ -250,9 +285,25 @@ struct QuestStagePacket
     uint16_t _pad;
 };
 
+struct QuestStageP2PPacket
+{
+    uint32_t phaseId; // PX-2
+    uint32_t questHash;
+    uint16_t stage;
+    uint16_t _pad;
+};
+
 struct QuestResyncRequestPacket
 {
     uint32_t _pad; // unused
+};
+
+struct SceneTriggerPacket
+{
+    uint32_t phaseId; // PX-1
+    uint32_t nameHash;
+    uint8_t start;
+    uint8_t _pad[3];
 };
 
 struct QuestEntry
@@ -382,6 +433,9 @@ struct CineStartPacket
 {
     uint32_t sceneId;
     uint32_t startTimeMs;
+    uint32_t phaseId; // PX-4
+    uint8_t solo;
+    uint8_t _pad[3];
 };
 
 struct VisemePacket
@@ -426,6 +480,8 @@ struct VendorStockItem
 {
     uint32_t itemId;
     uint32_t price;
+    uint16_t qty;
+    uint16_t _pad;
 };
 
 struct VendorStockPacket
@@ -434,6 +490,14 @@ struct VendorStockPacket
     uint8_t count;
     uint8_t _pad[3];
     VendorStockItem items[8];
+};
+
+struct VendorStockUpdatePacket
+{
+    uint32_t vendorId;
+    uint32_t itemId;
+    uint16_t qty;
+    uint16_t _pad;
 };
 
 struct PurchaseRequestPacket
@@ -452,15 +516,203 @@ struct PurchaseResultPacket
     uint8_t _pad[3];
 };
 
+struct WorldMarkersPacket
+{
+    uint16_t blobBytes;
+    uint8_t zstdBlob[1];
+};
+
+struct NpcSpawnCruiserPacket
+{
+    uint8_t waveIdx;
+    uint8_t _pad[3];
+    uint32_t npcSeeds[4];
+};
+
+struct NpcStatePacket
+{
+    uint32_t npcId;
+    uint8_t aiState;
+    uint8_t _pad[3];
+};
+
+struct CrimeEventSpawnPacket
+{
+    uint32_t eventId;
+    uint32_t seed;
+    uint8_t count;
+    uint8_t _pad[3];
+    uint32_t npcIds[4];
+};
+
+struct CyberEquipPacket
+{
+    uint32_t peerId;
+    uint8_t slotId;
+    uint8_t _pad[3];
+    ItemSnap snap;
+};
+
+struct SlowMoStartPacket
+{
+    uint32_t peerId;
+    float factor;
+    uint16_t durationMs;
+    uint16_t _pad;
+};
+
+struct PerkUnlockPacket
+{
+    uint32_t peerId;
+    uint32_t perkId;
+    uint8_t rank;
+    uint8_t _pad[3];
+};
+
+struct PerkRespecRequestPacket
+{
+    uint32_t peerId;
+};
+
+struct PerkRespecAckPacket
+{
+    uint32_t peerId;
+    uint16_t newPoints;
+    uint8_t _pad[2];
+};
+
+struct StatusApplyPacket
+{
+    uint32_t targetId;
+    uint8_t effectId;
+    uint16_t durMs;
+    uint8_t amp;
+};
+
+struct StatusTickPacket
+{
+    uint32_t targetId;
+    int16_t hpDelta;
+};
+
+struct TrafficSeedPacket
+{
+    uint64_t sectorHash;
+    uint64_t seed64;
+};
+
+struct TrafficDespawnPacket
+{
+    uint32_t vehId;
+};
+
+struct PropBreakPacket
+{
+    uint32_t entityId;
+    uint32_t seed;
+};
+
+struct PropIgnitePacket
+{
+    uint32_t entityId;
+    uint16_t delayMs;
+    uint16_t _pad;
+};
+
+struct VOPlayPacket
+{
+    uint32_t lineId;
+};
+
+struct FixerCallPacket
+{
+    uint32_t fixerId;
+};
+
+struct GigSpawnPacket
+{
+    uint32_t questId;
+    uint32_t seed;
+};
+
+struct VehicleSummonPacket
+{
+    uint32_t vehId;
+    uint32_t ownerId;
+    TransformSnap pos;
+};
+
+struct AppearancePacket
+{
+    uint32_t peerId;
+    uint32_t meshId;
+    uint32_t tintId;
+};
+
+struct PingOutlinePacket
+{
+    uint32_t peerId;
+    uint8_t count;
+    uint8_t _pad;
+    uint16_t durationMs;
+    uint32_t entityIds[32];
+};
+
+struct LootRollPacket
+{
+    uint32_t containerId;
+    uint32_t seed;
+};
+
+struct DealerBuyPacket
+{
+    uint32_t vehicleTpl;
+    uint32_t price;
+};
+
+struct VehicleUnlockPacket
+{
+    uint32_t peerId;
+    uint32_t vehicleTpl;
+};
+
+struct WeaponInspectPacket
+{
+    uint32_t peerId;
+    uint16_t animId;
+    uint16_t _pad;
+};
+
+struct FinisherStartPacket
+{
+    uint32_t actorId;
+    uint32_t victimId;
+    uint16_t animId;
+    uint16_t _pad;
+};
+
+struct FinisherEndPacket
+{
+    uint32_t actorId;
+};
+
+struct TextureBiasPacket
+{
+    uint8_t bias;
+    uint8_t _pad[3];
+};
+
 struct AvatarSpawnPacket
 {
     uint32_t peerId;
     TransformSnap snap;
+    uint32_t phaseId; // PX-1
 };
 
 struct AvatarDespawnPacket
 {
     uint32_t peerId;
+    uint32_t phaseId; // PX-1
 };
 
 struct ChatPacket

--- a/cp2077-coop/src/net/Snapshot.hpp
+++ b/cp2077-coop/src/net/Snapshot.hpp
@@ -64,6 +64,15 @@ enum class NpcState : uint8_t
     Combat
 };
 
+// PD-2 pursuit AI state
+enum class PoliceAIState : uint8_t
+{
+    Idle = 0,
+    Search,
+    Pursuit,
+    Combat
+};
+
 struct NpcSnap
 {
     uint32_t npcId;         // always included
@@ -73,8 +82,11 @@ struct NpcSnap
     Quaternion rot;         // delta bit 1
     NpcState state;         // delta bit 2
     uint16_t health;        // delta bit 3 (0 => despawn)
+    uint8_t aiState;        // PD-2
     uint8_t appearanceSeed; // full snap only
-}; 
+    uint8_t _pad[2];
+    uint32_t phaseId; // PX-1
+};
 static_assert(sizeof(NpcSnap) % 4 == 0, "NpcSnap must align to 4 bytes");
 static_assert(std::is_trivially_copyable_v<NpcSnap>, "NpcSnap must be trivial");
 
@@ -84,15 +96,15 @@ static_assert(std::is_trivially_copyable_v<NpcSnap>, "NpcSnap must be trivial");
 // slots are marked via slotMask bit per attachment slot.
 struct ItemSnap
 {
-    uint64_t itemId;            // always included
-    uint32_t ownerId;           // always included
-    uint16_t tpl;               // full snap only (base archetype)
-    uint16_t level;             // delta bit 0
-    uint16_t quality;           // delta bit 1
-    uint32_t rolls[4];          // delta bits 2..5
-    uint8_t slotMask;           // delta bit 6
+    uint64_t itemId;   // always included
+    uint32_t ownerId;  // always included
+    uint16_t tpl;      // full snap only (base archetype)
+    uint16_t level;    // delta bit 0
+    uint16_t quality;  // delta bit 1
+    uint32_t rolls[4]; // delta bits 2..5
+    uint8_t slotMask;  // delta bit 6
     uint8_t _pad[3];
-    uint64_t attachmentIds[4];  // delta bits 7..10
+    uint64_t attachmentIds[4]; // delta bits 7..10
 };
 static_assert(sizeof(ItemSnap) % 4 == 0, "ItemSnap must align to 4 bytes");
 static_assert(std::is_trivially_copyable_v<ItemSnap>, "ItemSnap must be trivial");

--- a/cp2077-coop/src/net/WorldMarkers.cpp
+++ b/cp2077-coop/src/net/WorldMarkers.cpp
@@ -1,0 +1,46 @@
+#include "../../third_party/zstd/zstd.h"
+#include "Net.hpp"
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+namespace CoopNet
+{
+
+std::vector<uint8_t> BuildMarkerBlob()
+{
+    RED4ext::DynArray<RED4ext::Vector3> pos;
+    RED4ext::ExecuteFunction("WorldMarkerHelpers", "GatherPositions", nullptr, &pos);
+    uint16_t count = static_cast<uint16_t>(pos.size);
+    std::vector<uint8_t> raw(sizeof(uint16_t) + count * sizeof(RED4ext::Vector3));
+    std::memcpy(raw.data(), &count, sizeof(uint16_t));
+    if (count > 0)
+        std::memcpy(raw.data() + sizeof(uint16_t), pos.Begin(), count * sizeof(RED4ext::Vector3));
+    size_t bound = ZSTD_compressBound(raw.size());
+    std::vector<uint8_t> out(bound);
+    size_t z = ZSTD_compress(out.data(), bound, raw.data(), raw.size(), 1);
+    if (ZSTD_isError(z))
+        return {};
+    out.resize(z);
+    return out;
+}
+
+void ApplyMarkerBlob(const uint8_t* buf, size_t len)
+{
+    std::vector<uint8_t> raw(10240);
+    size_t size = ZSTD_decompress(raw.data(), raw.size(), buf, len);
+    if (ZSTD_isError(size))
+        return;
+    raw.resize(size);
+    if (raw.size() < sizeof(uint16_t))
+        return;
+    uint16_t count;
+    std::memcpy(&count, raw.data(), sizeof(uint16_t));
+    const RED4ext::Vector3* arr = reinterpret_cast<const RED4ext::Vector3*>(raw.data() + sizeof(uint16_t));
+    for (uint16_t i = 0; i < count; ++i)
+    {
+        RED4ext::ExecuteFunction("WorldMarkerHelpers", "ApplyPosition", nullptr, &arr[i]);
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/runtime/CrimeSpawner.reds
+++ b/cp2077-coop/src/runtime/CrimeSpawner.reds
@@ -1,0 +1,5 @@
+public class CrimeSpawner {
+    public static func OnEvent(pkt: ref<CrimeEventSpawnPacket>) -> Void {
+        LogChannel(n"ncpd", "Crime event id=" + IntToString(Cast<Int32>(pkt.eventId)));
+    }
+}

--- a/cp2077-coop/src/runtime/CutsceneSync.reds
+++ b/cp2077-coop/src/runtime/CutsceneSync.reds
@@ -74,6 +74,6 @@ protected func gamevision_StartCinematic(original: func(ref<gamevision>, Uint32,
   original(self, sceneId, startMs);
   CutsceneSync.OnCineStart(sceneId, startMs);
   if Net_IsAuthoritative() {
-    Net_BroadcastCineStart(sceneId, startMs);
+    Net_BroadcastCineStart(sceneId, startMs, QuestSync.localPhase, false);
   };
 }

--- a/cp2077-coop/src/runtime/CyberwareSync.reds
+++ b/cp2077-coop/src/runtime/CyberwareSync.reds
@@ -1,0 +1,39 @@
+// Handles cyberware equip replication and slow-motion events.
+public class CyberwareSync {
+    public static let slowMoEnd: Uint64 = 0u;
+    public static let slowMoFactor: Float = 1.0;
+
+    public static func OnEquip(peer: Uint32, slot: Uint8, snap: ref<ItemSnap>) -> Void {
+        Inventory.OnItemSnap(snap);
+        if peer == Net_GetLocalPeerId() {
+            // Reload meshes for local player
+            AvatarProxy.ReloadCyberware(slot);
+        };
+        QuickhackSync.RefreshSlots(peer);
+    }
+
+    public static func OnSlowMo(peer: Uint32, factor: Float, durMs: Uint16) -> Void {
+        if peer != Net_GetLocalPeerId() {
+            slowMoEnd = CoopNet.GameClock.GetCurrentTick() + Cast<Uint64>(durMs / CoopNet.GameClock.currentTickMs);
+            slowMoFactor = factor;
+        };
+    }
+
+    public static func Tick(dt: Float) -> Void {
+        if slowMoEnd > 0u {
+            if CoopNet.GameClock.GetCurrentTick() >= slowMoEnd {
+                slowMoEnd = 0u;
+                slowMoFactor = 1.0;
+            };
+        }
+    }
+}
+
+public static func CyberwareSync_OnEquip(peer: Uint32, slot: Uint8, snap: ItemSnap) -> Void {
+    let s = snap;
+    CyberwareSync.OnEquip(peer, slot, &s);
+}
+
+public static func CyberwareSync_OnSlowMo(peer: Uint32, factor: Float, dur: Uint16) -> Void {
+    CyberwareSync.OnSlowMo(peer, factor, dur);
+}

--- a/cp2077-coop/src/runtime/FixerCallSync.reds
+++ b/cp2077-coop/src/runtime/FixerCallSync.reds
@@ -1,0 +1,20 @@
+public class FixerCallSync {
+    public static var currentId: Uint32 = 0u;
+
+    public static func OnStart(id: Uint32) -> Void {
+        currentId = id;
+        LogChannel(n"fixer", "Call start id=" + IntToString(Cast<Int32>(id)));
+    }
+
+    public static func OnEnd(id: Uint32) -> Void {
+        LogChannel(n"fixer", "Call end id=" + IntToString(Cast<Int32>(id)));
+    }
+}
+
+public static func FixerCallSync_OnStart(id: Uint32) -> Void {
+    FixerCallSync.OnStart(id);
+}
+
+public static func FixerCallSync_OnEnd(id: Uint32) -> Void {
+    FixerCallSync.OnEnd(id);
+}

--- a/cp2077-coop/src/runtime/FixerPhone.reds
+++ b/cp2077-coop/src/runtime/FixerPhone.reds
@@ -1,0 +1,24 @@
+@wrapMethod(PhoneSystem)
+protected func StartCall(fixerId: CName) -> Void {
+    if GameModeManager.current != GameMode.Coop {
+        wrappedMethod(fixerId);
+        return;
+    };
+    let idHash: Uint32 = CoopNet.Fnv1a32(NameToString(fixerId));
+    if Net_IsAuthoritative() {
+        CoopNet.Net_BroadcastFixerCallStart(idHash);
+    };
+    FixerCallSync.OnStart(idHash);
+}
+
+@wrapMethod(PhoneSystem)
+protected func EndCall() -> Void {
+    if GameModeManager.current != GameMode.Coop {
+        wrappedMethod();
+        return;
+    };
+    if Net_IsAuthoritative() {
+        CoopNet.Net_BroadcastFixerCallEnd(FixerCallSync.currentId);
+    };
+    FixerCallSync.OnEnd(FixerCallSync.currentId);
+}

--- a/cp2077-coop/src/runtime/GigSpawner.reds
+++ b/cp2077-coop/src/runtime/GigSpawner.reds
@@ -1,0 +1,17 @@
+public class GigSpawnVolume extends ScriptedTriggerBase {
+    public let questId: Uint32;
+    private let triggered: Bool;
+
+    protected cb func OnEnter(instigator: ref<GameObject>) -> Bool {
+        if triggered { return false; };
+        if !Net_IsAuthoritative() { return false; };
+        triggered = true;
+        let seed: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(questId)) + IntToString(Cast<Int32>(GameInstance.GetSimTime(GetGame()))));
+        CoopNet.Net_BroadcastGigSpawn(questId, seed);
+        return true;
+    }
+}
+
+public static func GigSpawner_OnSpawn(q: Uint32, s: Uint32) -> Void {
+    LogChannel(n"gig", "Spawn quest=" + IntToString(Cast<Int32>(q)));
+}

--- a/cp2077-coop/src/runtime/HeatSync.reds
+++ b/cp2077-coop/src/runtime/HeatSync.reds
@@ -5,12 +5,18 @@ public class HeatSync {
     public static let damageScale: Float = 1.0;
 
     public static func BroadcastHeat(level: Uint8) -> Void {
+        if level > heatLevel {
+            PoliceDispatch.OnHeat(level);
+        };
         heatLevel = level;
         Net_BroadcastHeat(level);
         LogChannel(n"DEBUG", "BroadcastHeat " + IntToString(level));
     }
 
     public static func ApplyHeat(level: Uint8) -> Void {
+        if level > heatLevel {
+            PoliceDispatch.OnHeat(level);
+        };
         heatLevel = level;
         LogChannel(n"DEBUG", "ApplyHeat " + IntToString(level));
     }

--- a/cp2077-coop/src/runtime/Inventory.reds
+++ b/cp2077-coop/src/runtime/Inventory.reds
@@ -46,7 +46,7 @@ public class Inventory {
         } else {
             LogChannel(n"DEBUG", "Purchase failed " + Uint64ToString(itemId));
         };
-        // FIXME(next ticket): update wallet UI
+        Vendor.OnPurchaseResult(itemId, balance, success);
     }
 
     public static func RequestCraft(recipeId: Uint32) -> Void {

--- a/cp2077-coop/src/runtime/Inventory/Vendor.reds
+++ b/cp2077-coop/src/runtime/Inventory/Vendor.reds
@@ -1,0 +1,11 @@
+// Handles vendor purchase results on the client.
+public class Vendor {
+    public static func OnPurchaseResult(itemId: Uint64, bal: Uint64, success: Bool) -> Void {
+        if success {
+            LogChannel(n"vendor", "Purchase ok");
+        } else {
+            LogChannel(n"vendor", "Purchase failed");
+        };
+        WalletHud.Update(Int64(bal));
+    }
+}

--- a/cp2077-coop/src/runtime/LootAuthority.reds
+++ b/cp2077-coop/src/runtime/LootAuthority.reds
@@ -7,4 +7,12 @@ public class LootAuthority {
         LogChannel(n"DEBUG", "CanPickup " + Uint64ToString(itemId) + " by " + IntToString(peerId));
         return true;
     }
+
+    public static func OnLootRoll(containerId: Uint32, seed: Uint32) -> Void {
+        LogChannel(n"loot", "roll " + IntToString(containerId) + " seed " + IntToString(seed));
+    }
+}
+
+public static func LootAuthority_OnLootRoll(id: Uint32, seed: Uint32) -> Void {
+    LootAuthority.OnLootRoll(id, seed);
 }

--- a/cp2077-coop/src/runtime/NpcProxy.reds
+++ b/cp2077-coop/src/runtime/NpcProxy.reds
@@ -4,6 +4,7 @@ public class NpcProxy extends gameObject {
     public var pos: Vector3;
     public var rot: Quaternion;
     public var state: NpcState;
+    public var aiState: PoliceAIState;
     public var health: Uint16;
     public var appearanceSeed: Uint8;
     public var sectorHash: Uint64;
@@ -16,6 +17,7 @@ public class NpcProxy extends gameObject {
         pos = snap.pos;
         rot = snap.rot;
         state = snap.state;
+        aiState = Cast<PoliceAIState>(snap.aiState);
         health = snap.health;
         LogChannel(n"DEBUG", "NpcProxy.Spawn " + IntToString(npcId) + " tpl=" + IntToString(templateId));
         // Placeholder mesh spawn
@@ -26,6 +28,7 @@ public class NpcProxy extends gameObject {
         pos = snap.pos;
         rot = snap.rot;
         state = snap.state;
+        aiState = Cast<PoliceAIState>(snap.aiState);
         health = snap.health;
         sectorHash = snap.sectorHash;
         switch state {
@@ -58,6 +61,11 @@ public class NpcProxy extends gameObject {
 
     public func Despawn() -> Void {
         LogChannel(n"DEBUG", "NpcProxy.Despawn " + IntToString(npcId));
+    }
+
+    public func OnAIState(stateVal: Uint8) -> Void {
+        aiState = Cast<PoliceAIState>(stateVal);
+        LogChannel(n"ncpd", "AIState " + IntToString(Cast<Int32>(stateVal)));
     }
 
     private func SetAnimation(name: CName) -> Void {

--- a/cp2077-coop/src/runtime/PerkSync.reds
+++ b/cp2077-coop/src/runtime/PerkSync.reds
@@ -1,0 +1,20 @@
+public class PerkSync {
+    public static let hud : ref<inkHashMap> = new inkHashMap();
+
+    public static func RequestUnlock(perkId: Uint32, rank: Uint8) -> Void {
+        Net_SendPerkUnlock(perkId, rank);
+    }
+
+    public static func OnUnlock(peerId: Uint32, perkId: Uint32, rank: Uint8) -> Void {
+        let map = hud.Get(peerId) as inkHashMap;
+        if !IsDefined(map) {
+            map = new inkHashMap();
+            hud.Insert(peerId, map);
+        };
+        map.Insert(perkId, rank);
+    }
+
+    public static func OnRespecAck(peerId: Uint32, pts: Uint16) -> Void {
+        LogChannel(n"perk", "Respec done newPoints=" + IntToString(pts));
+    }
+}

--- a/cp2077-coop/src/runtime/PhotoModeBlock.reds
+++ b/cp2077-coop/src/runtime/PhotoModeBlock.reds
@@ -1,0 +1,11 @@
+// Disables photo mode during multiplayer sessions.
+
+@wrapMethod(PhotoModeSystem)
+protected func Enter() -> Void {
+    if GameModeManager.current != GameMode.Coop {
+        wrappedMethod();
+        return;
+    };
+    PopupGuard.ReplaceWithCoopNotice(n"PhotoMode");
+    LogChannel(n"DEBUG", "[PhotoMode] blocked");
+}

--- a/cp2077-coop/src/runtime/PoliceDispatch.reds
+++ b/cp2077-coop/src/runtime/PoliceDispatch.reds
@@ -1,0 +1,34 @@
+public class PoliceDispatch {
+    public static let waveTimerMs: Uint32 = 0u;
+    public static let nextWaveIdx: Uint8 = 0u;
+    private static let prevHeat: Uint8 = 0u;
+
+    public static func OnHeat(level: Uint8) -> Void {
+        if level > prevHeat {
+            waveTimerMs = 0u;
+            nextWaveIdx = 0u;
+        };
+        prevHeat = level;
+    }
+
+    public static func Tick(dtMs: Uint32) -> Void {
+        waveTimerMs += dtMs;
+        let interval: Uint32 = HeatSync.heatLevel >= 3u ? 15000u : 30000u;
+        if waveTimerMs >= interval {
+            waveTimerMs = 0u;
+            var seeds: array<Uint32>;
+            let count: Uint32 = Cast<Uint32>(Net_GetPeerCount());
+            var i: Int32 = 0;
+            while i < 4 {
+                seeds[i] = CoopNet.Fnv1a32(IntToString(Cast<Int32>(count)) + IntToString(Cast<Int32>(nextWaveIdx)) + IntToString(i));
+                i += 1;
+            };
+            Net_BroadcastNpcSpawnCruiser(nextWaveIdx, seeds);
+            nextWaveIdx += 1u;
+        };
+    }
+
+    public static func OnCruiserSpawn(idx: Uint8, seeds0: Uint32, seeds1: Uint32, seeds2: Uint32, seeds3: Uint32) -> Void {
+        LogChannel(n"ncpd", "Spawn cruiser wave " + IntToString(Cast<Int32>(idx)));
+    }
+}

--- a/cp2077-coop/src/runtime/PropSync.reds
+++ b/cp2077-coop/src/runtime/PropSync.reds
@@ -1,0 +1,39 @@
+public class PropSync {
+    public static func OnBreak(id: Uint32, seed: Uint32) -> Void {
+        LogChannel(n"prop", "Break " + IntToString(Cast<Int32>(id)) + " seed=" + IntToString(Cast<Int32>(seed)));
+    }
+
+    public static func OnIgnite(id: Uint32, delay: Uint16) -> Void {
+        LogChannel(n"prop", "Ignite " + IntToString(Cast<Int32>(id)) + " delay=" + IntToString(Cast<Int32>(delay)));
+    }
+
+    public static func ScheduleChain(prop: ref<physicsProp>, seed: Uint32) -> Void {
+        let query = GameInstance.GetWorldQuerySystem(GetGame());
+        if !IsDefined(query) { return; };
+        let pos = prop.GetWorldPosition();
+        let actors: array<ref<GameObject>>;
+        query.GetActorsInSphere(pos, 8.0, actors);
+        for obj in actors {
+            let barrel = obj as physicsProp;
+            if IsDefined(barrel) && barrel.IsExplosive() && barrel != prop {
+                let delay: Uint16 = Cast<Uint16>(100u + (seed & 0xFFu) % 200u);
+                CoopNet.Net_BroadcastPropIgnite(Cast<Uint32>(EntityID.GetHash(barrel.GetEntityID())), delay);
+            };
+        };
+    }
+
+    public static func HandleBreak(prop: ref<physicsProp>) -> Void {
+        if Net_IsAuthoritative() {
+            let id: Uint32 = Cast<Uint32>(EntityID.GetHash(prop.GetEntityID()));
+            let seed: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(id)) + IntToString(Cast<Int32>(GameInstance.GetSimTime(GetGame()))));
+            CoopNet.Net_BroadcastPropBreak(id, seed);
+            if prop.IsExplosive() { ScheduleChain(prop, seed); };
+        };
+    }
+}
+
+@hook(physicsProp.OnBreak)
+protected func physicsProp_OnBreak(original: func(ref<physicsProp>), self: ref<physicsProp>) -> Void {
+    original(self);
+    PropSync.HandleBreak(self);
+}

--- a/cp2077-coop/src/runtime/QuestSync.reds
+++ b/cp2077-coop/src/runtime/QuestSync.reds
@@ -4,6 +4,7 @@
 // These helpers send stage and scene updates between peers.
 public class QuestSync {
     public static var freezeQuests: Bool = false;
+    public static var localPhase: Uint32 = 0u; // PX-2
     public static let stageMap: ref<inkHashMap> = new inkHashMap();
     public static let nameMap: ref<inkHashMap> = new inkHashMap();
     // Called after the game advances a quest stage on the server.
@@ -20,7 +21,7 @@ public class QuestSync {
         let hash: Uint32 = CoopNet.Fnv1a32(NameToString(questName));
         nameMap.Insert(hash, questName);
         stageMap.Insert(hash, stage);
-        CoopNet.Net_BroadcastQuestStage(hash, stage);
+        CoopNet.Net_BroadcastQuestStageP2P(localPhase, hash, stage);
         LogChannel(n"DEBUG", "SendQuestStageMsg " + NameToString(questName) + " stage=" + ToString(stage));
     }
 
@@ -48,6 +49,7 @@ public class QuestSync {
     }
 
     public static func ApplyFullSync(pkt: ref<QuestFullSyncPacket>) -> Void {
+        LogChannel(n"quest", "[Watchdog] forced sync");
         let count: Uint16 = pkt.count;
         let i: Uint16 = 0u;
         while i < count {

--- a/cp2077-coop/src/runtime/QuickhackSync.reds
+++ b/cp2077-coop/src/runtime/QuickhackSync.reds
@@ -97,4 +97,12 @@ public class QuickhackSync {
             LogChannel(n"DEBUG", "Daemon mass vulnerability 30s");
         };
     }
+
+    public static func OnPingOutline(peerId: Uint32, ids: array<Uint32>, dur: Uint16) -> Void {
+        for id in ids { LogChannel(n"ping", "outline " + IntToString(id)); };
+    }
+}
+
+public static func QuickhackSync_OnPingOutline(peer: Uint32, dur: Uint16, ids: array<Uint32>) -> Void {
+    QuickhackSync.OnPingOutline(peer, ids, dur);
 }

--- a/cp2077-coop/src/runtime/Respawn.reds
+++ b/cp2077-coop/src/runtime/Respawn.reds
@@ -34,8 +34,7 @@ public class Respawn {
             avatar.health = 100u;
             avatar.armor = 100u;
             avatar.OnVitalsChanged();
-            if HasMethod(avatar, n"SetGodMode") { avatar.SetGodMode(true); };
-            GameInstance.GetDelaySystem(GetGame()).DelayCallback(avatar, n"ClearInvuln", 2.0);
+            avatar.StartSpawnProtection(5000u);
         }
         let board = DMScoreboard.Instance();
         board.deaths += 1u;

--- a/cp2077-coop/src/runtime/StatusEffectSync.reds
+++ b/cp2077-coop/src/runtime/StatusEffectSync.reds
@@ -1,0 +1,36 @@
+// Handles replication of status effects (burn, shock, poison, EMP).
+public class StatusEffectSync {
+    public static func OnApply(id: Uint32, eff: Uint8, dur: Uint16, amp: Uint8) -> Void {
+        LogChannel(n"status", "Apply effect=" + IntToString(Cast<Int32>(eff)));
+        let obj = GameInstance.FindEntityByID(Cast<EntityID>(id)) as GameObject;
+        if !IsDefined(obj) { return; };
+        let effSys = GameInstance.GetScriptableSystemsContainer(GetGame()).Get(n"EffectSystem") as EffectSystem;
+        if !IsDefined(effSys) { return; };
+        let vfx: Uint32 = 0u;
+        switch eff {
+            case 1u:
+                vfx = CoopNet.Fnv1a32("burning_body.ent");
+            case 2u:
+                vfx = CoopNet.Fnv1a32("shock_body.ent");
+            case 3u:
+                vfx = CoopNet.Fnv1a32("poison_body.ent");
+            case 4u:
+                vfx = CoopNet.Fnv1a32("emp_sparks.ent");
+            default:
+        };
+        if vfx != 0u {
+            effSys.SpawnEffect(vfx, obj.GetWorldPosition());
+        };
+    }
+    public static func OnTick(id: Uint32, delta: Int16) -> Void {
+        LogChannel(n"status", "Tick target=" + IntToString(Cast<Int32>(id)));
+    }
+}
+
+public static func StatusEffectSync_OnApply(id: Uint32, eff: Uint8, dur: Uint16, amp: Uint8) -> Void {
+    StatusEffectSync.OnApply(id, eff, dur, amp);
+}
+
+public static func StatusEffectSync_OnTick(id: Uint32, delta: Int16) -> Void {
+    StatusEffectSync.OnTick(id, delta);
+}

--- a/cp2077-coop/src/runtime/TextureBiasSync.reds
+++ b/cp2077-coop/src/runtime/TextureBiasSync.reds
@@ -1,0 +1,11 @@
+public class TextureBiasSync {
+    public static var bias: Uint8 = 0u;
+    public static func Apply(newBias: Uint8) -> Void {
+        bias = newBias;
+        LogChannel(n"mem", "Mip bias=" + IntToString(Cast<Int32>(newBias)));
+    }
+}
+
+public static func TextureBiasSync_OnChange(bias: Uint8) -> Void {
+    TextureBiasSync.Apply(bias);
+}

--- a/cp2077-coop/src/runtime/TrafficSync.reds
+++ b/cp2077-coop/src/runtime/TrafficSync.reds
@@ -1,0 +1,17 @@
+// Feeds ghost traffic seeds to the local simulator.
+public class TrafficSync {
+    public static func OnSeed(hash: Uint64, seed: Uint64) -> Void {
+        LogChannel(n"traffic", "Seed sector=" + IntToString(Cast<Int32>(hash)));
+    }
+    public static func OnDespawn(id: Uint32) -> Void {
+        LogChannel(n"traffic", "Despawn veh=" + IntToString(Cast<Int32>(id)));
+    }
+}
+
+public static func TrafficSync_OnSeed(hash: Uint64, seed: Uint64) -> Void {
+    TrafficSync.OnSeed(hash, seed);
+}
+
+public static func TrafficSync_OnDespawn(id: Uint32) -> Void {
+    TrafficSync.OnDespawn(id);
+}

--- a/cp2077-coop/src/runtime/VehicleSummonSync.reds
+++ b/cp2077-coop/src/runtime/VehicleSummonSync.reds
@@ -1,0 +1,13 @@
+public class VehicleSummonSync {
+    public static func OnSummon(pkt: ref<VehicleSummonPacket>) -> Void {
+        VehicleProxy_Spawn(pkt^.vehId, &pkt^.pos);
+    }
+}
+
+public static func VehicleSummonSync_OnSummon(id: Uint32, owner: Uint32, pos: ref<TransformSnap>) -> Void {
+    let p: VehicleSummonPacket;
+    p.vehId = id;
+    p.ownerId = owner;
+    p.pos = pos^;
+    VehicleSummonSync.OnSummon(&p);
+}

--- a/cp2077-coop/src/runtime/VehicleUnlockSync.reds
+++ b/cp2077-coop/src/runtime/VehicleUnlockSync.reds
@@ -1,0 +1,9 @@
+public class VehicleUnlockSync {
+    public static func OnUnlock(peer: Uint32, tpl: Uint32) -> Void {
+        LogChannel(n"dealer", "Vehicle unlocked " + IntToString(tpl) + " for " + IntToString(peer));
+    }
+}
+
+public static func VehicleUnlockSync_OnUnlock(peer: Uint32, tpl: Uint32) -> Void {
+    VehicleUnlockSync.OnUnlock(peer, tpl);
+}

--- a/cp2077-coop/src/runtime/VendorSync.reds
+++ b/cp2077-coop/src/runtime/VendorSync.reds
@@ -4,4 +4,19 @@ public class VendorSync {
     public static func OnStock(pkt: ref<VendorStockPacket>) -> Void {
         stock.Insert(pkt.vendorId, pkt);
     }
+
+    public static func OnStockUpdate(pkt: ref<VendorStockUpdatePacket>) -> Void {
+        let entry = stock.Get(pkt.vendorId) as VendorStockPacket;
+        if IsDefined(entry) {
+            let count: Int32 = Cast<Int32>(entry.count);
+            var i: Int32 = 0;
+            while i < count {
+                if entry.items[i].itemId == pkt.itemId {
+                    entry.items[i].qty = pkt.qty;
+                    break;
+                };
+                i += 1;
+            };
+        };
+    }
 }

--- a/cp2077-coop/src/runtime/WeaponSync.reds
+++ b/cp2077-coop/src/runtime/WeaponSync.reds
@@ -1,0 +1,31 @@
+public class WeaponSync {
+    public static func OnInspect(peer: Uint32, anim: Uint16) -> Void {
+        LogChannel(n"weapon", "Inspect peer=" + IntToString(Cast<Int32>(peer)));
+        let avatar = GameInstance.GetPlayerSystem(GetGame()).FindObject(peer) as AvatarProxy;
+        if IsDefined(avatar) {
+            if HasMethod(avatar, n"PlayInspect") {
+                avatar.PlayInspect(anim);
+            };
+        };
+    }
+
+    public static func OnFinisherStart(actor: Uint32, victim: Uint32, anim: Uint16) -> Void {
+        LogChannel(n"weapon", "Finisher start actor=" + IntToString(Cast<Int32>(actor)));
+    }
+
+    public static func OnFinisherEnd(actor: Uint32) -> Void {
+        LogChannel(n"weapon", "Finisher end actor=" + IntToString(Cast<Int32>(actor)));
+    }
+}
+
+public static func WeaponSync_OnInspect(peer: Uint32, anim: Uint16) -> Void {
+    WeaponSync.OnInspect(peer, anim);
+}
+
+public static func WeaponSync_OnFinisherStart(actor: Uint32, victim: Uint32, anim: Uint16) -> Void {
+    WeaponSync.OnFinisherStart(actor, victim, anim);
+}
+
+public static func WeaponSync_OnFinisherEnd(actor: Uint32) -> Void {
+    WeaponSync.OnFinisherEnd(actor);
+}

--- a/cp2077-coop/src/runtime/WeatherSync.reds
+++ b/cp2077-coop/src/runtime/WeatherSync.reds
@@ -1,24 +1,24 @@
 // Synchronizes time of day and weather between players.
 public struct WorldState {
-    public var worldClock: Uint64;
-    public var weatherSeed: Uint32;
-    public var sunAngle: Uint32; // degrees * 100
+    public var sunAngleDeg: Uint16;   // rounded degrees
     public var weatherId: Uint8;
-    public var braindancePhase: Uint8;
 }
 
 public class WeatherSync {
     public static let lastBroadcast: Float = 0.0;
-    private static let kInterval: Float = 5.0;
+    private static let kInterval: Float = 30.0;
 
     // Called on server when world state changes or every 30 s.
     public static func Broadcast(state: ref<WorldState>) -> Void {
         // NetCore.BroadcastWorldState(state);
         lastBroadcast = EngineTime.ToFloat(GameInstance.GetTimeSystem(GetGame()).GetGameTime());
-        LogChannel(n"DEBUG", "BroadcastWorldState clock=" + IntToString(Cast<Int64>(state.worldClock)));
+        LogChannel(n"weather", "Sun " + IntToString(state.sunAngleDeg) + "  Weather " + IntToString(state.weatherId));
     }
 
     public static func Apply(state: ref<WorldState>) -> Void {
-        LogChannel(n"DEBUG", "ApplyWorldState weather=" + IntToString(state.weatherId));
+        let ts = GameInstance.GetTimeSystem(GetGame());
+        ts.SetSunRotation(Cast<Float>(state.sunAngleDeg));
+        let ws = GameInstance.GetWeatherSystem(GetGame());
+        ws.SetWeather(state.weatherId);
     }
 }

--- a/cp2077-coop/src/runtime/WorldMarkerHelpers.reds
+++ b/cp2077-coop/src/runtime/WorldMarkerHelpers.reds
@@ -1,0 +1,25 @@
+public class WorldMarkerHelpers {
+    public static func GatherPositions() -> array<Vector3> {
+        let res: array<Vector3>;
+        let qs = QuestSystem.GetInstance(GetGame());
+        if IsDefined(qs) {
+            let gigs = qs.ListOpenActivities();
+            for g in gigs { res.PushBack(g.position); };
+        };
+        let mm = MinimapSystem.GetInstance(GetGame());
+        if IsDefined(mm) {
+            let pins = mm.GetCustomPins();
+            for p in pins { res.PushBack(p); };
+        };
+        let ncpd = NCPDSystem.GetInstance(GetGame());
+        if IsDefined(ncpd) {
+            let events = ncpd.GetNearbyEvents(500.0);
+            for e in events { res.PushBack(e.pos); };
+        };
+        return res;
+    }
+
+    public static func ApplyPosition(pos: Vector3) -> Void {
+        CoopMap.AddMarker(pos);
+    }
+}

--- a/cp2077-coop/src/server/CyberController.cpp
+++ b/cp2077-coop/src/server/CyberController.cpp
@@ -1,0 +1,37 @@
+#include "CyberController.hpp"
+#include "../net/Net.hpp"
+#include <RED4ext/RED4ext.hpp>
+#include <iostream>
+
+namespace CoopNet
+{
+
+static bool CheckPrereqs(uint8_t slotId)
+{
+    uint32_t cred = 0;
+    RED4ext::ExecuteFunction("PlayerProgression", "GetStreetCredLevel", nullptr, &cred);
+    if (cred < 10)
+        return false;
+    uint32_t capacity = 0;
+    RED4ext::ExecuteFunction("StatsSystem", "GetCyberCapacity", nullptr, &capacity);
+    if (capacity < slotId)
+        return false;
+    return true;
+}
+
+void CyberController_Equip(Connection* conn, uint8_t slotId, const ItemSnap& snap)
+{
+    if (!CheckPrereqs(slotId))
+    {
+        std::cout << "Equip blocked: prereqs failed" << std::endl;
+        return;
+    }
+    CyberEquipPacket pkt{};
+    pkt.peerId = conn->peerId;
+    pkt.slotId = slotId;
+    pkt.snap = snap;
+    Net_Broadcast(EMsg::CyberEquip, &pkt, sizeof(pkt));
+    Net_BroadcastAppearance(conn->peerId, snap.tpl, 0u);
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/CyberController.hpp
+++ b/cp2077-coop/src/server/CyberController.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include "../net/Connection.hpp"
+#include "../net/Packets.hpp"
+
+namespace CoopNet
+{
+void CyberController_Equip(Connection* conn, uint8_t slotId, const ItemSnap& snap);
+}

--- a/cp2077-coop/src/server/DamageValidator.cpp
+++ b/cp2077-coop/src/server/DamageValidator.cpp
@@ -1,15 +1,24 @@
+#include "PerkController.hpp"
+#include "ServerConfig.hpp"
 #include <iostream>
 
 namespace CoopNet
 {
-bool ValidateDamage(uint16_t rawDmg, uint16_t targetArmor)
+uint16_t FilterDamage(uint32_t sourcePeer, uint32_t targetPeer, bool targetIsNpc, uint16_t rawDmg, uint16_t targetArmor,
+                      bool invulnerable)
 {
-    uint16_t maxAllowed = targetArmor * 4 + 200;
+    if (invulnerable)
+        return 0;
+    if (!g_cfgFriendlyFire && (sourcePeer == targetPeer || !targetIsNpc))
+        return 0;
+
+    float mult = PerkController_GetHealthMult(targetPeer);
+    uint16_t maxAllowed = static_cast<uint16_t>((targetArmor * 4 + 200) * mult);
     if (rawDmg > maxAllowed)
     {
         std::cout << "cheat detected" << std::endl;
-        return false;
+        return maxAllowed;
     }
-    return true;
+    return rawDmg;
 }
 } // namespace CoopNet

--- a/cp2077-coop/src/server/DamageValidator.hpp
+++ b/cp2077-coop/src/server/DamageValidator.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+namespace CoopNet
+{
+uint16_t FilterDamage(uint32_t sourcePeer, uint32_t targetPeer, bool targetIsNpc, uint16_t rawDmg, uint16_t targetArmor,
+                      bool invulnerable);
+}

--- a/cp2077-coop/src/server/DealerController.cpp
+++ b/cp2077-coop/src/server/DealerController.cpp
@@ -1,0 +1,23 @@
+#include "DealerController.hpp"
+#include "../net/Net.hpp"
+#include "LedgerService.hpp"
+#include "SessionState.hpp"
+#include "VehicleController.hpp"
+#include <iostream>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace CoopNet
+{
+static std::unordered_map<uint32_t, std::unordered_set<uint32_t>> g_owned;
+
+void DealerController_HandleBuy(Connection* conn, uint32_t vehicleTpl, uint32_t price)
+{
+    uint64_t bal;
+    if (!Ledger_Transfer(conn, -static_cast<int64_t>(price), 0, bal))
+        return;
+    g_owned[conn->peerId].insert(vehicleTpl);
+    Net_BroadcastVehicleUnlock(conn->peerId, vehicleTpl);
+    std::cout << "DealerBuy tpl=" << vehicleTpl << " by peer=" << conn->peerId << std::endl;
+}
+} // namespace CoopNet

--- a/cp2077-coop/src/server/DealerController.hpp
+++ b/cp2077-coop/src/server/DealerController.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "../net/Connection.hpp"
+
+namespace CoopNet
+{
+void DealerController_HandleBuy(Connection* conn, uint32_t vehicleTpl, uint32_t price);
+}

--- a/cp2077-coop/src/server/DedicatedMain.cpp
+++ b/cp2077-coop/src/server/DedicatedMain.cpp
@@ -1,15 +1,22 @@
 #include "../core/GameClock.hpp"
-#include "../core/SessionState.hpp"
 #include "../core/SaveMigration.hpp"
+#include "../core/SessionState.hpp"
 #include "../net/Net.hpp"
+#include "AdminController.hpp"
 #include "BreachController.hpp"
 #include "ElevatorController.hpp"
-#include "NpcController.hpp"
-#include "VehicleController.hpp"
-#include "AdminController.hpp"
-#include "Heartbeat.hpp"
-#include "WebDash.hpp"
 #include "GlobalEventController.hpp"
+#include "Heartbeat.hpp"
+#include "NpcController.hpp"
+#include "PoliceDispatch.hpp"
+#include "ServerConfig.hpp"
+#include "SnapshotHeap.hpp"
+#include "StatusController.hpp"
+#include "TextureGuard.hpp"
+#include "TrafficController.hpp"
+#include "VehicleController.hpp"
+#include "WebDash.hpp"
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <thread>
@@ -24,9 +31,10 @@ int main(int argc, char** argv)
         }
     }
 
+    CoopNet::ServerConfig_Load();
     Net_Init();
     CoopNet::MigrateSinglePlayerSave();
-    CoopNet::TransformSnap vs{ {0.f,0.f,0.f}, {0.f,0.f,0.f,1.f}, {0.f,0.f,0.f} };
+    CoopNet::TransformSnap vs{{0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 1.f}, {0.f, 0.f, 0.f}};
     CoopNet::VehicleController_Spawn(CoopNet::Fnv1a32("vehicle_caliburn"), 0u, vs);
     CoopNet::WebDash_Start();
     CoopNet::AdminController_Start();
@@ -38,6 +46,8 @@ int main(int argc, char** argv)
     uint8_t weatherId = 0u;
     uint8_t bdPhase = 0u;
     float worldTimer = 0.f;
+    uint16_t lastSunDeg = 0u;
+    uint8_t lastWeather = weatherId;
 
     // Main server loop
     bool running = true;
@@ -46,6 +56,7 @@ int main(int argc, char** argv)
     int frameCount = 0;
     float goodTime = 0.f;
     float hbTimer = 0.f;
+    float memTimer = 0.f;
     float tickMs = CoopNet::GameClock::GetTickMs();
     bool validated = false;
     auto last = std::chrono::steady_clock::now();
@@ -65,10 +76,16 @@ int main(int argc, char** argv)
         worldClock += static_cast<uint64_t>(tickMs);
         sunAngle = (sunAngle + static_cast<uint32_t>(tickMs)) % 36000;
         worldTimer += tickMs / 1000.f;
-        if (worldTimer >= 5.f)
+        uint16_t deg = static_cast<uint16_t>((sunAngle + 50) / 100);
+        if (deg >= 360)
+            deg = 0;
+        bool changed = std::abs(static_cast<int>(deg) - static_cast<int>(lastSunDeg)) >= 5 || weatherId != lastWeather;
+        if (worldTimer >= 30.f || changed)
         {
             worldTimer = 0.f;
-            Net_BroadcastWorldState(worldClock, sunAngle, weatherId, weatherSeed, bdPhase);
+            lastSunDeg = deg;
+            lastWeather = weatherId;
+            Net_BroadcastWorldState(deg, weatherId);
         }
         CoopNet::ElevatorController_ServerTick(tickMs);
         if (!CoopNet::ElevatorController_IsPaused())
@@ -77,11 +94,17 @@ int main(int argc, char** argv)
             CoopNet::VehicleController_ServerTick(tickMs);
             CoopNet::BreachController_ServerTick(tickMs);
             CoopNet::VendorController_Tick(tickMs);
+            CoopNet::PoliceDispatch_Tick(tickMs);
+            CoopNet::StatusController_Tick(tickMs);
+            CoopNet::TrafficController_Tick(tickMs);
             RED4ext::ExecuteFunction("GameModeManager", "TickDM", nullptr, static_cast<uint32_t>(tickMs));
         }
         Net_Poll(static_cast<uint32_t>(tickMs));
+        CoopNet::QuestWatchdog_Tick(tickMs);
         CoopNet::AdminController_PollCommands();
         hbTimer += tickMs / 1000.f;
+        memTimer += tickMs / 1000.f;
+        CoopNet::TextureGuard_Tick(tickMs / 1000.f);
         if (hbTimer >= 30.f)
         {
             hbTimer = 0.f;
@@ -89,6 +112,11 @@ int main(int argc, char** argv)
             uint32_t id = CoopNet::SessionState_GetId();
             std::string json = "{\"players\":" + std::to_string(count) + ",\"hash\":" + std::to_string(id) + "}";
             CoopNet::Heartbeat_Announce(json);
+        }
+        if (memTimer >= 60.f)
+        {
+            memTimer = 0.f;
+            CoopNet::SnapshotMemCheck();
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(tickMs)));
 

--- a/cp2077-coop/src/server/PerkController.cpp
+++ b/cp2077-coop/src/server/PerkController.cpp
@@ -1,0 +1,51 @@
+#include "PerkController.hpp"
+#include "../core/SessionState.hpp"
+#include "../net/Net.hpp"
+#include "LedgerService.hpp"
+#include <iostream>
+#include <unordered_map>
+
+namespace CoopNet
+{
+
+struct PerkData
+{
+    uint8_t rank;
+    float healthMult;
+};
+static std::unordered_map<uint32_t, std::unordered_map<uint32_t, PerkData>> g_perks;
+
+float PerkController_GetHealthMult(uint32_t peerId)
+{
+    float mult = 1.f;
+    auto itPeer = g_perks.find(peerId);
+    if (itPeer != g_perks.end())
+    {
+        for (auto& kv : itPeer->second)
+            mult *= kv.second.healthMult;
+    }
+    return mult;
+}
+
+void PerkController_HandleUnlock(Connection* conn, uint32_t perkId, uint8_t rank)
+{
+    float mult = 1.f + 0.05f * static_cast<float>(rank);
+    g_perks[conn->peerId][perkId] = {rank, mult};
+    SessionState_SetPerk(conn->peerId, perkId, rank);
+    Net_BroadcastPerkUnlock(conn->peerId, perkId, rank);
+    std::cout << "PerkUnlock peer=" << conn->peerId << " perk=" << perkId << " rank=" << static_cast<int>(rank)
+              << std::endl;
+}
+
+void PerkController_HandleRespec(Connection* conn)
+{
+    uint64_t balance;
+    if (!Ledger_Transfer(conn, -100000, 0, balance))
+        return;
+    g_perks[conn->peerId].clear();
+    SessionState_ClearPerks(conn->peerId);
+    Net_SendPerkRespecAck(conn, 0);
+    std::cout << "PerkRespec peer=" << conn->peerId << std::endl;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/PerkController.hpp
+++ b/cp2077-coop/src/server/PerkController.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "../net/Connection.hpp"
+#include <cstdint>
+
+namespace CoopNet
+{
+void PerkController_HandleUnlock(Connection* conn, uint32_t perkId, uint8_t rank);
+void PerkController_HandleRespec(Connection* conn);
+float PerkController_GetHealthMult(uint32_t peerId);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/PoliceDispatch.cpp
+++ b/cp2077-coop/src/server/PoliceDispatch.cpp
@@ -1,0 +1,56 @@
+#include "PoliceDispatch.hpp"
+#include "../core/Hash.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <RED4ext/RED4ext.hpp>
+#include <cstring>
+
+namespace CoopNet
+{
+static uint32_t g_timer = 0;
+static uint8_t g_waveIdx = 0;
+static uint8_t g_heat = 0;
+static uint32_t g_maxtac = 0;
+
+void PoliceDispatch_OnHeatChange(uint8_t level)
+{
+    if (level > g_heat)
+    {
+        g_timer = 0;
+        g_waveIdx = 0;
+    }
+    g_heat = level;
+    RED4ext::ExecuteFunction("PoliceDispatch", "OnHeat", nullptr, level);
+}
+
+void PoliceDispatch_Tick(float dt)
+{
+    if (g_heat == 0)
+        return;
+    g_timer += static_cast<uint32_t>(dt);
+    g_maxtac += static_cast<uint32_t>(dt);
+    uint32_t interval = (g_heat >= 3 ? 15000u : 30000u);
+    if (g_timer >= interval)
+    {
+        g_timer = 0;
+        uint32_t seeds[4];
+        uint32_t count = static_cast<uint32_t>(Net_GetConnections().size());
+        for (int i = 0; i < 4; ++i)
+            seeds[i] = Fnv1a32(std::to_string(count).c_str()) ^ (g_waveIdx * 31u + i);
+        Net_BroadcastNpcSpawnCruiser(g_waveIdx, seeds);
+        g_waveIdx++;
+    }
+    if (g_heat >= 5)
+    {
+        if (g_maxtac >= 60000u)
+        {
+            g_maxtac = 0;
+            Net_BroadcastCineStart(Fnv1a32("maxtac_av"), 0, 0, false);
+        }
+    }
+    else
+    {
+        g_maxtac = 0;
+    }
+}
+} // namespace CoopNet

--- a/cp2077-coop/src/server/PoliceDispatch.hpp
+++ b/cp2077-coop/src/server/PoliceDispatch.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet
+{
+void PoliceDispatch_OnHeatChange(uint8_t level);
+void PoliceDispatch_Tick(float dt);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/QuestWatchdog.cpp
+++ b/cp2077-coop/src/server/QuestWatchdog.cpp
@@ -1,0 +1,99 @@
+#include "QuestWatchdog.hpp"
+#include "../net/Net.hpp"
+#include <unordered_map>
+
+namespace CoopNet
+{
+
+static std::unordered_map<uint32_t, std::unordered_map<uint32_t, uint16_t>> g_phaseStages; // PX-2
+static std::unordered_map<uint32_t, float> g_diverge;
+static float g_timer = 0.f;
+static uint32_t g_resyncCount = 0;
+static float g_window = 0.f;
+
+void QuestWatchdog_Record(uint32_t phaseId, uint32_t questHash, uint16_t stage)
+{
+    g_phaseStages[phaseId][questHash] = stage;
+}
+
+void QuestWatchdog_BuildFullSync(uint32_t phaseId, QuestFullSyncPacket& outPkt)
+{
+    outPkt.count = 0;
+    auto it = g_phaseStages.find(phaseId);
+    if (it == g_phaseStages.end())
+        return;
+    for (auto& q : it->second)
+    {
+        if (outPkt.count >= 32)
+            break;
+        outPkt.entries[outPkt.count].nameHash = q.first;
+        outPkt.entries[outPkt.count].stage = q.second;
+        ++outPkt.count;
+    }
+}
+
+void QuestWatchdog_Tick(float dt)
+{
+    g_timer += dt;
+    g_window += dt;
+    if (g_window >= 300.f)
+    {
+        g_window = 0.f;
+        g_resyncCount = 0;
+    }
+    if (g_timer < 3.f)
+        return;
+    g_timer = 0.f;
+
+    std::unordered_map<uint32_t, uint16_t> minStage;
+    std::unordered_map<uint32_t, uint16_t> maxStage;
+    for (auto& peer : g_phaseStages)
+    {
+        for (auto& q : peer.second)
+        {
+            uint16_t st = q.second;
+            auto& mn = minStage[q.first];
+            if (mn == 0 || st < mn)
+                mn = st;
+            auto& mx = maxStage[q.first];
+            if (st > mx)
+                mx = st;
+        }
+    }
+
+    for (auto& kv : maxStage)
+    {
+        uint32_t hash = kv.first;
+        uint16_t mx = kv.second;
+        uint16_t mn = minStage[hash];
+        if (mx > mn + 1)
+        {
+            g_diverge[hash] += 3.f;
+            if (g_diverge[hash] > 15.f && g_resyncCount < 2)
+            {
+                g_resyncCount++;
+                for (auto& peer : g_phaseStages)
+                {
+                    uint16_t st = peer.second[hash];
+                    if (st != mx)
+                    {
+                        Connection* conn = Net_FindConnection(peer.first);
+                        if (conn)
+                        {
+                            QuestFullSyncPacket pkt{};
+                            QuestWatchdog_BuildFullSync(peer.first, pkt);
+                            Net_SendQuestFullSync(conn, pkt);
+                        }
+                    }
+                }
+                g_diverge.erase(hash);
+            }
+        }
+        else
+        {
+            g_diverge.erase(hash);
+        }
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/QuestWatchdog.hpp
+++ b/cp2077-coop/src/server/QuestWatchdog.hpp
@@ -1,0 +1,16 @@
+#ifndef COOP_QUEST_WATCHDOG_HPP
+#define COOP_QUEST_WATCHDOG_HPP
+
+#include "../net/Packets.hpp"
+#include <cstdint>
+
+namespace CoopNet
+{
+
+void QuestWatchdog_Record(uint32_t phaseId, uint32_t questHash, uint16_t stage); // PX-2
+void QuestWatchdog_Tick(float dt);
+void QuestWatchdog_BuildFullSync(uint32_t phaseId, QuestFullSyncPacket& outPkt); // PX-2
+
+} // namespace CoopNet
+
+#endif // COOP_QUEST_WATCHDOG_HPP

--- a/cp2077-coop/src/server/ServerConfig.cpp
+++ b/cp2077-coop/src/server/ServerConfig.cpp
@@ -1,0 +1,37 @@
+#include "ServerConfig.hpp"
+#include <algorithm>
+#include <fstream>
+#include <string>
+
+namespace CoopNet
+{
+
+bool g_cfgFriendlyFire = false;
+
+static bool ParseBool(const std::string& s)
+{
+    std::string v = s;
+    std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+    return v == "1" || v == "true" || v == "yes";
+}
+
+void ServerConfig_Load()
+{
+    g_cfgFriendlyFire = false;
+    std::ifstream in("coop_dedicated.ini");
+    if (!in.is_open())
+        return;
+    std::string line;
+    while (std::getline(in, line))
+    {
+        size_t eq = line.find('=');
+        if (eq == std::string::npos)
+            continue;
+        std::string key = line.substr(0, eq);
+        std::string val = line.substr(eq + 1);
+        if (key == "friendly_fire")
+            g_cfgFriendlyFire = ParseBool(val);
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/ServerConfig.hpp
+++ b/cp2077-coop/src/server/ServerConfig.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+namespace CoopNet
+{
+extern bool g_cfgFriendlyFire;
+void ServerConfig_Load();
+} // namespace CoopNet

--- a/cp2077-coop/src/server/SnapshotHeap.cpp
+++ b/cp2077-coop/src/server/SnapshotHeap.cpp
@@ -1,0 +1,55 @@
+#include "SnapshotHeap.hpp"
+#include "../core/GameClock.hpp"
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <malloc.h>
+#include <vector>
+
+namespace CoopNet
+{
+struct Entry
+{
+    uint64_t time;
+    size_t bytes;
+};
+static std::vector<Entry> g_entries;
+
+void SnapshotStore_Add(size_t bytes)
+{
+    g_entries.push_back({GameClock::GetTimeMs(), bytes});
+}
+
+void SnapshotStore_PurgeOld(float ageSec)
+{
+    uint64_t now = GameClock::GetTimeMs();
+    g_entries.erase(std::remove_if(g_entries.begin(), g_entries.end(), [&](const Entry& e)
+                                   { return now - e.time > static_cast<uint64_t>(ageSec * 1000.f); }),
+                    g_entries.end());
+}
+
+size_t SnapshotStore_GetMemory()
+{
+    size_t total = 0;
+    for (auto& e : g_entries)
+        total += e.bytes;
+    return total;
+}
+
+void SnapshotMemCheck()
+{
+#ifdef __GLIBC__
+    struct mallinfo mi = mallinfo();
+    size_t used = static_cast<size_t>(mi.uordblks);
+#else
+    size_t used = 0;
+#endif
+    used = std::max(used, SnapshotStore_GetMemory());
+    if (used > (size_t(2) << 30))
+    {
+        SnapshotStore_PurgeOld(300.f);
+        std::cerr << "[MemGuard] snapshot heap high, purged old baselines" << std::endl;
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/SnapshotHeap.hpp
+++ b/cp2077-coop/src/server/SnapshotHeap.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <cstddef>
+
+namespace CoopNet
+{
+void SnapshotStore_Add(size_t bytes);
+void SnapshotStore_PurgeOld(float ageSec);
+size_t SnapshotStore_GetMemory();
+void SnapshotMemCheck();
+} // namespace CoopNet

--- a/cp2077-coop/src/server/StatusController.cpp
+++ b/cp2077-coop/src/server/StatusController.cpp
@@ -1,0 +1,44 @@
+#include "StatusController.hpp"
+#include "../net/Net.hpp"
+#include "DamageValidator.hpp"
+#include <vector>
+
+namespace CoopNet
+{
+struct StatusEntry
+{
+    uint32_t targetId;
+    uint8_t effectId;
+    uint8_t amp;
+    uint16_t remaining;
+    uint16_t tickTimer;
+};
+
+static std::vector<StatusEntry> g_entries;
+
+void StatusController_OnApply(Connection* src, const StatusApplyPacket& pkt)
+{
+    StatusEntry e{pkt.targetId, pkt.effectId, pkt.amp, pkt.durMs, 0};
+    g_entries.push_back(e);
+    Net_BroadcastStatusApply(pkt.targetId, pkt.effectId, pkt.durMs, pkt.amp);
+}
+
+void StatusController_Tick(float dt)
+{
+    for (auto it = g_entries.begin(); it != g_entries.end();)
+    {
+        it->remaining = (it->remaining > dt) ? static_cast<uint16_t>(it->remaining - dt) : 0;
+        it->tickTimer += static_cast<uint16_t>(dt);
+        if (it->tickTimer >= 500)
+        {
+            it->tickTimer -= 500;
+            Net_BroadcastStatusTick(it->targetId, -static_cast<int16_t>(it->amp));
+        }
+        if (it->remaining == 0)
+            it = g_entries.erase(it);
+        else
+            ++it;
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/StatusController.hpp
+++ b/cp2077-coop/src/server/StatusController.hpp
@@ -1,0 +1,16 @@
+#ifndef COOP_STATUS_CONTROLLER_HPP
+#define COOP_STATUS_CONTROLLER_HPP
+
+#include "../net/Connection.hpp"
+#include "../net/Packets.hpp"
+#include <cstdint>
+
+namespace CoopNet
+{
+
+void StatusController_OnApply(Connection* src, const StatusApplyPacket& pkt);
+void StatusController_Tick(float dt);
+
+} // namespace CoopNet
+
+#endif // COOP_STATUS_CONTROLLER_HPP

--- a/cp2077-coop/src/server/TextureGuard.hpp
+++ b/cp2077-coop/src/server/TextureGuard.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet
+{
+void TextureGuard_Tick(float dt);
+}

--- a/cp2077-coop/src/server/TrafficController.cpp
+++ b/cp2077-coop/src/server/TrafficController.cpp
@@ -1,0 +1,29 @@
+#include "TrafficController.hpp"
+#include "../core/GameClock.hpp"
+#include "../net/Net.hpp"
+#include <unordered_map>
+
+namespace CoopNet
+{
+static float g_seedTimer = 0.f;
+
+void TrafficController_Tick(float dtMs)
+{
+    g_seedTimer += dtMs;
+    if (g_seedTimer >= 10000.f)
+    {
+        g_seedTimer = 0.f;
+        uint64_t sector = 0;
+        if (!Net_GetConnections().empty())
+            sector = Net_GetConnections()[0]->currentSector;
+        uint64_t seed = static_cast<uint64_t>(CoopNet::GameClock::GetCurrentTick());
+        Net_BroadcastTrafficSeed(sector, seed);
+    }
+}
+
+void TrafficController_OnDespawn(uint32_t vehId)
+{
+    Net_BroadcastTrafficDespawn(vehId);
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/TrafficController.hpp
+++ b/cp2077-coop/src/server/TrafficController.hpp
@@ -1,0 +1,12 @@
+#ifndef COOP_TRAFFIC_CONTROLLER_HPP
+#define COOP_TRAFFIC_CONTROLLER_HPP
+
+#include <cstdint>
+
+namespace CoopNet
+{
+void TrafficController_Tick(float dtMs);
+void TrafficController_OnDespawn(uint32_t vehId);
+} // namespace CoopNet
+
+#endif // COOP_TRAFFIC_CONTROLLER_HPP

--- a/cp2077-coop/src/server/VehicleController.hpp
+++ b/cp2077-coop/src/server/VehicleController.hpp
@@ -1,7 +1,8 @@
 #pragma once
 #include "../net/Snapshot.hpp"
 
-namespace CoopNet {
+namespace CoopNet
+{
 void VehicleController_ServerTick(float dt);
 void VehicleController_ApplyDamage(uint16_t dmg, bool side);
 void VehicleController_SetOccupant(uint32_t peerId);
@@ -9,4 +10,5 @@ void VehicleController_Spawn(uint32_t archetype, uint32_t paint, const Transform
 void VehicleController_HandleSeatRequest(CoopNet::Connection* c, uint32_t vehicleId, uint8_t seatIdx);
 void VehicleController_HandleHit(uint32_t vehicleId, uint16_t dmg, bool side);
 void VehicleController_RemovePeer(uint32_t peerId);
-}
+void VehicleController_HandleSummon(CoopNet::Connection* c, uint32_t vehId, const TransformSnap& t);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/VendorController.cpp
+++ b/cp2077-coop/src/server/VendorController.cpp
@@ -12,10 +12,10 @@ namespace CoopNet
 
 struct VendorItem
 {
-    uint32_t id;
     uint32_t price;
+    uint16_t qty;
 };
-static std::unordered_map<uint32_t, std::vector<VendorItem>> g_stock;
+static std::unordered_map<uint32_t, std::unordered_map<uint32_t, VendorItem>> g_stock;
 static std::unordered_map<uint32_t, float> g_timer;
 
 void VendorController_Tick(float dt)
@@ -23,31 +23,45 @@ void VendorController_Tick(float dt)
     for (auto& kv : g_timer)
     {
         kv.second += dt;
-        if (kv.second >= 1800.f)
+        if (kv.second >= 3600.f)
         {
             kv.second = 0.f;
-            auto& list = g_stock[kv.first];
-            list.clear();
-            VendorItem item{kv.first * 10 + 1, 1000};
-            list.push_back(item);
+            auto& map = g_stock[kv.first];
+            map.clear();
+            VendorItem item{1000, 5};
+            map[kv.first * 10 + 1] = item;
             VendorStockPacket pkt{};
             pkt.vendorId = kv.first;
-            pkt.count = static_cast<uint8_t>(list.size());
-            for (size_t i = 0; i < list.size() && i < 8; ++i)
+            pkt.count = 0;
+            for (auto& it : map)
             {
-                pkt.items[i].itemId = list[i].id;
-                pkt.items[i].price = list[i].price;
+                if (pkt.count >= 8)
+                    break;
+                pkt.items[pkt.count].itemId = it.first;
+                pkt.items[pkt.count].price = it.second.price;
+                pkt.items[pkt.count].qty = it.second.qty;
+                ++pkt.count;
             }
             Net_BroadcastVendorStock(pkt);
         }
     }
 }
 
-static uint32_t CalculatePrice(const VendorItem& item, Connection* conn)
+static uint32_t CalculatePrice(uint32_t basePrice, Connection* conn)
 {
-    // FIXME(next ticket): include street cred and perks
-    (void)conn;
-    return item.price;
+    uint32_t cred = 0;
+    RED4ext::ExecuteFunction("PlayerProgression", "GetStreetCredLevel", nullptr, &cred);
+    bool hasPerk = false;
+    RED4ext::CName perk = "Wholesale";
+    RED4ext::ExecuteFunction("PerkSystem", "HasPerk", nullptr, &perk, &hasPerk);
+    int32_t price = static_cast<int32_t>(basePrice);
+    if (cred > 0 && cred <= 50)
+        price = (price * static_cast<int32_t>(100 - cred)) / 100;
+    if (hasPerk)
+        price = (price * 90) / 100;
+    if (price < 1)
+        price = 1;
+    return static_cast<uint32_t>(price);
 }
 
 void VendorController_HandlePurchase(Connection* conn, uint32_t vendorId, uint32_t itemId, uint64_t nonce)
@@ -55,33 +69,27 @@ void VendorController_HandlePurchase(Connection* conn, uint32_t vendorId, uint32
     auto it = g_stock.find(vendorId);
     if (it == g_stock.end())
         return;
-    auto& list = it->second;
-    auto itemIt = std::find_if(list.begin(), list.end(), [&](const VendorItem& v) { return v.id == itemId; });
-    if (itemIt == list.end())
+    auto& map = it->second;
+    auto itemIt = map.find(itemId);
+    if (itemIt == map.end() || itemIt->second.qty == 0)
         return;
     uint64_t balance;
-    uint32_t price = CalculatePrice(*itemIt, conn);
+    uint32_t price = CalculatePrice(itemIt->second.price, conn);
     if (!Ledger_Transfer(conn, -static_cast<int64_t>(price), nonce, balance))
     {
         PurchaseResultPacket res{vendorId, itemId, conn->balance, 0, {0, 0, 0}};
         Net_Send(conn, EMsg::PurchaseResult, &res, sizeof(res));
         return;
     }
-    ItemSnap snap = Inventory_CreateItem(static_cast<uint16_t>(itemIt->id), conn->peerId);
+    ItemSnap snap = Inventory_CreateItem(static_cast<uint16_t>(itemIt->first), conn->peerId);
     ItemSnapPacket pkt{snap};
     Net_Send(conn, EMsg::ItemSnap, &pkt, sizeof(pkt));
     PurchaseResultPacket res{vendorId, itemId, balance, 1, {0, 0, 0}};
     Net_Send(conn, EMsg::PurchaseResult, &res, sizeof(res));
-    list.erase(itemIt);
-    VendorStockPacket stock{};
-    stock.vendorId = vendorId;
-    stock.count = static_cast<uint8_t>(list.size());
-    for (size_t i = 0; i < list.size() && i < 8; ++i)
-    {
-        stock.items[i].itemId = list[i].id;
-        stock.items[i].price = list[i].price;
-    }
-    Net_BroadcastVendorStock(stock);
+    if (itemIt->second.qty > 0)
+        itemIt->second.qty -= 1;
+    VendorStockUpdatePacket upd{vendorId, itemId, itemIt->second.qty, 0};
+    Net_BroadcastVendorStockUpdate(upd);
 }
 
 } // namespace CoopNet

--- a/cp2077-coop/src/voice/VoiceDecoder.hpp
+++ b/cp2077-coop/src/voice/VoiceDecoder.hpp
@@ -5,4 +5,5 @@ namespace CoopVoice
 {
 void PushPacket(uint16_t seq, const uint8_t* data, uint16_t size);
 int DecodeFrame(int16_t* pcmOut);
+uint16_t ConsumeDropPct();
 } // namespace CoopVoice

--- a/cp2077-coop/tests/static/price_cases.json
+++ b/cp2077-coop/tests/static/price_cases.json
@@ -1,0 +1,32 @@
+[
+    {
+        "base": 100,
+        "cred": 1,
+        "perk": false,
+        "price": 99
+    },
+    {
+        "base": 100,
+        "cred": 50,
+        "perk": false,
+        "price": 50
+    },
+    {
+        "base": 100,
+        "cred": 25,
+        "perk": true,
+        "price": 67
+    },
+    {
+        "base": 1,
+        "cred": 50,
+        "perk": true,
+        "price": 1
+    },
+    {
+        "base": 200,
+        "cred": 5,
+        "perk": false,
+        "price": 190
+    }
+]

--- a/cp2077-coop/third_party/zstd/zstd.h
+++ b/cp2077-coop/third_party/zstd/zstd.h
@@ -1,0 +1,15 @@
+#ifndef ZSTD_H
+#define ZSTD_H
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    size_t ZSTD_compress(void* dst, size_t dstCapacity, const void* src, size_t srcSize, int level);
+    size_t ZSTD_decompress(void* dst, size_t dstCapacity, const void* src, size_t compressedSize);
+    unsigned ZSTD_isError(size_t code);
+    size_t ZSTD_compressBound(size_t srcSize);
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
### Ticket
WI-1 · Inspect animation sync
WI-2 · Finisher cinematic sync
MB-3 · Adaptive texture LOD down-scaler

### Summary
* Added new packet IDs for weapon inspect, finisher start/end and texture bias changes
* Broadcast helpers encode these events and connection handlers forward them to runtime
* Implemented `WeaponSync.reds` for playing inspect and finisher events on clients
* `TextureGuard` monitors VRAM usage and broadcasts global mip bias adjustments
* `DedicatedMain` calls `TextureGuard_Tick` each frame

### Files Touched
- `src/net/Packets.hpp` (+28)
- `src/net/Net.hpp` (+5)
- `src/net/Net.cpp` (+30)
- `src/net/Connection.cpp` (+36)
- `src/server/TextureGuard.cpp` **(new)**
- `src/server/TextureGuard.hpp` **(new)**
- `src/runtime/WeaponSync.reds` **(new)**
- `src/runtime/TextureBiasSync.reds` **(new)**
- `src/server/DedicatedMain.cpp` (+1)
- `CMakeLists.txt` (+1)

### Logic Walk-Through
1. `TextureGuard_Tick` checks VRAM ratio every 30 s, adjusts mip bias when sustained high/low usage and broadcasts `TextureBiasChange`.
2. `Net_BroadcastWeaponInspect` and related helpers serialize small structs for sync.
3. `Connection::HandlePacket` routes incoming packets to `WeaponSync` and `TextureBiasSync` functions.
4. New runtime scripts log the events and stub out animation calls.

### Unfinished / TODO
- Actual animation playback for finishers still placeholder.

### Testing Performed
- `pre-commit` hooks auto-fixed whitespace and formatting (clang-format, EOF).


------
https://chatgpt.com/codex/tasks/task_e_685dc04f750083308e032653012b7704