### PR TITLE
Add AI sync packets and stubs

### DIFF
--- a/cp2077-coop/Apartments.csv
+++ b/cp2077-coop/Apartments.csv
@@ -1,0 +1,3 @@
+aptId,x,y,z,price,interiorScene,extDoorId
+1,0.0,0.0,0.0,15000,apt_std_01,1001
+2,10.0,5.0,0.0,20000,apt_std_02,1002

--- a/cp2077-coop/CMakeLists.txt
+++ b/cp2077-coop/CMakeLists.txt
@@ -1,89 +1,59 @@
-cmake_minimum_required(VERSION 3.21)
-project(cp2077-coop)
+cmake_minimum_required(VERSION 3.21) project(cp2077 - coop)
 
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+    list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
-find_package(Juice REQUIRED)
-find_package(Opus REQUIRED)
-find_package(AL REQUIRED)
-find_package(OpenSSL REQUIRED)
+        find_package(Juice REQUIRED) find_package(Opus REQUIRED) find_package(AL REQUIRED)
+            find_package(OpenSSL REQUIRED)
 
-# See README for build and packaging instructions.
-# This CMake script builds the cp2077-coop mod and the coop_dedicated server.
+#See README for build and packaging instructions.
+#This CMake script builds the cp2077 - coop mod and the coop_dedicated server.
 
-# Build the mod's native library.
-add_library(cp2077-coop SHARED
-    src/net/Net.cpp
-    src/net/Connection.cpp
-    src/net/StatBatch.cpp
-    src/net/NatClient.cpp
-    src/net/WorldMarkers.cpp
-    src/net/PhaseBundle.cpp
-    src/core/GameClock.cpp
-    src/core/SpatialGrid.cpp
-    src/core/SaveFork.cpp
-    src/core/SaveMigration.cpp
-    src/core/Settings.cpp
-    src/core/SessionState.cpp
-    src/core/CrashHandler.cpp
-    src/physics/LagComp.cpp
-    src/physics/CarPhysics.cpp
-    src/server/InventoryController.cpp
-    src/server/VendorController.cpp
-    src/server/DealerController.cpp
-    src/server/NpcController.cpp
-    src/server/VehicleController.cpp
-    src/server/BreachController.cpp
-    src/server/ElevatorController.cpp
-    src/server/GlobalEventController.cpp
-    src/server/AdminController.cpp
-    src/server/CyberController.cpp
-    src/server/PerkController.cpp
-    src/server/QuestWatchdog.cpp
-    src/server/SnapshotHeap.cpp
-    src/server/TextureGuard.cpp
-    src/server/PoliceDispatch.cpp
-    src/server/LedgerService.cpp
-    src/server/WebDash.cpp
-    src/voice/VoiceEncoder.cpp
-    src/voice/VoiceDecoder.cpp
-)
+#Build the mod's native library.
+                add_library(cp2077 - coop SHARED src / net / Net.cpp src / net / Connection.cpp src / net /
+                                         StatBatch.cpp src / net / NatClient.cpp src / net / WorldMarkers.cpp src /
+                                         net / PhaseBundle.cpp src / core / GameClock.cpp src / core /
+                                         SpatialGrid.cpp src / core / SaveFork.cpp src / core / SaveMigration.cpp src /
+                                         core / Settings.cpp src / core / SessionState.cpp src / core /
+                                         CrashHandler.cpp src / physics / LagComp.cpp src / physics /
+                                         CarPhysics.cpp src / server / InventoryController.cpp src / server /
+                                         VendorController.cpp src / server / ApartmentController.cpp src / server /
+                                         DealerController.cpp src / server / NpcController.cpp src / server /
+                                         VehicleController.cpp src / server / BreachController.cpp src / server /
+                                         ShardController.cpp src / server / ElevatorController.cpp src / server /
+                                         GlobalEventController.cpp src / server / AdminController.cpp src / server /
+                                         CyberController.cpp src / server / PerkController.cpp src / server /
+                                         SkillController.cpp src / server / QuestWatchdog.cpp src / server /
+                                         PhaseGC.cpp src / server / PhaseTriggerController.cpp src / server /
+                                         TradeController.cpp src / server /
+                                         SnapshotHeap.cpp src / server / TextureGuard.cpp src / server /
+                                         PoliceDispatch.cpp src / server / LedgerService.cpp src / server /
+                                         WebDash.cpp src / voice / VoiceEncoder.cpp src / voice / VoiceDecoder.cpp)
 
-target_include_directories(cp2077-coop
-    PRIVATE
-        "${PROJECT_SOURCE_DIR}/third_party/enet/include"
-        "${PROJECT_SOURCE_DIR}/third_party"
-        "${PROJECT_SOURCE_DIR}/third_party/zstd"
-)
+                    target_include_directories(cp2077 - coop PRIVATE "${PROJECT_SOURCE_DIR}/third_party/enet/include"
+                                                                     "${PROJECT_SOURCE_DIR}/third_party"
+                                                                     "${PROJECT_SOURCE_DIR}/third_party/zstd")
 
-target_link_libraries(cp2077-coop PRIVATE enet juice opus AL::AL OpenSSL::SSL)
+                        target_link_libraries(cp2077 - coop PRIVATE enet juice opus AL::AL OpenSSL::SSL)
 
-set(BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build")
-file(MAKE_DIRECTORY "${BUILD_DIR}")
+                            set(BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build") file(MAKE_DIRECTORY "${BUILD_DIR}")
 
-set(ARCHIVE "${BUILD_DIR}/cp2077-coop.archive")
-add_custom_command(
-    OUTPUT "${ARCHIVE}"
-    COMMAND ${CMAKE_COMMAND} -E touch "${ARCHIVE}"
-    COMMENT "Creating empty archive"
-)
+                                set(ARCHIVE "${BUILD_DIR}/cp2077-coop.archive")
+                                    add_custom_command(OUTPUT "${ARCHIVE}" COMMAND ${CMAKE_COMMAND} - E touch
+                                                       "${ARCHIVE}" COMMENT "Creating empty archive")
 
-add_executable(coop_dedicated
-    src/server/DedicatedMain.cpp
-    src/server/DamageValidator.cpp
-    src/server/ServerConfig.cpp
-    src/server/Heartbeat.cpp
-    src/server/AdminController.cpp
-)
+                                        add_executable(coop_dedicated src / server / DedicatedMain.cpp src / server /
+                                                       DamageValidator.cpp src / server / ServerConfig.cpp src /
+                                                       server / Heartbeat.cpp src / server / AdminController.cpp)
 
-target_include_directories(coop_dedicated PRIVATE "${PROJECT_SOURCE_DIR}/third_party")
+                                            target_include_directories(coop_dedicated PRIVATE
+                                                                       "${PROJECT_SOURCE_DIR}/third_party")
 
-target_link_libraries(coop_dedicated PRIVATE cp2077-coop enet juice)
+                                                target_link_libraries(coop_dedicated PRIVATE cp2077 - coop enet juice)
 
-add_executable(coop_merge
-    tools/coop_merge.cpp
-)
+                                                    add_executable(coop_merge tools / coop_merge.cpp)
 
-target_link_libraries(coop_merge PRIVATE cp2077-coop)
+                                                        target_link_libraries(coop_merge PRIVATE cp2077 - coop)
 
-add_custom_target(cp2077-coop-archive ALL DEPENDS "${ARCHIVE}" cp2077-coop)
+                                                            add_custom_target(cp2077 - coop -
+                                                                              archive ALL DEPENDS "${ARCHIVE}" cp2077 -
+                                                                              coop)

--- a/cp2077-coop/CriticalQuests.json
+++ b/cp2077-coop/CriticalQuests.json
@@ -1,4 +1,10 @@
-#questHash,
-    stage 123456,
-    2 789012,
-    3
+[
+    {
+        "questHash": 123456,
+        "stage": 2
+    },
+    {
+        "questHash": 789012,
+        "stage": 3
+    }
+]

--- a/cp2077-coop/RomanceScenes.json
+++ b/cp2077-coop/RomanceScenes.json
@@ -1,0 +1,12 @@
+[
+    {
+        "questHash": 111111,
+        "stage": 200,
+        "sceneId": 12345
+    },
+    {
+        "questHash": 222222,
+        "stage": 100,
+        "sceneId": 67890
+    }
+]

--- a/cp2077-coop/assets/ui/ezestates.html
+++ b/cp2077-coop/assets/ui/ezestates.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><script src="ezestates.js"></script></head>
+<body>
+<div id="aptList"></div>
+</body>
+</html>

--- a/cp2077-coop/assets/ui/ezestates.js
+++ b/cp2077-coop/assets/ui/ezestates.js
@@ -1,0 +1,22 @@
+const apartments = [ {id : 1, price : 15000}, {id : 2, price : 20000} ];
+function send(id)
+{
+    if (window.nk)
+    {
+        window.nk.call('CoopPurchaseApt', id);
+    }
+}
+function render()
+{
+    const root = document.getElementById('aptList');
+    apartments.forEach(a => {
+        const row = document.createElement('div');
+        const buy = document.createElement('button');
+        buy.textContent = 'Buy';
+        buy.onclick = () => send(a.id);
+        row.textContent = `Apartment ${a.id} - $${a.price}`;
+        row.appendChild(buy);
+        root.appendChild(row);
+    });
+}
+window.addEventListener('DOMContentLoaded', render);

--- a/cp2077-coop/src/audio/VoiceOverQueue.reds
+++ b/cp2077-coop/src/audio/VoiceOverQueue.reds
@@ -6,6 +6,13 @@ public struct VOEvent {
 public class VoiceOverQueue {
     public static let events: array<VOEvent>;
 
+    public static func Play(lineId: Uint32) -> Void {
+        if Net_IsAuthoritative() {
+            CoopNet.Net_BroadcastVOPlay(lineId);
+            OnPlay(lineId);
+        };
+    }
+
     public static func OnPlay(lineId: Uint32) -> Void {
         let ts = GameClock.GetTime();
         let evt: VOEvent;

--- a/cp2077-coop/src/core/FinisherType.hpp
+++ b/cp2077-coop/src/core/FinisherType.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet
+{
+
+enum class FinisherType : uint8_t
+{
+    None = 0,
+    Pistol = 1,
+    Knife = 2,
+    Revolver = 3
+};
+
+} // namespace CoopNet

--- a/cp2077-coop/src/core/SaveFork.cpp
+++ b/cp2077-coop/src/core/SaveFork.cpp
@@ -1,9 +1,12 @@
 #include "SaveFork.hpp"
 // Saves are written with Content-Encoding: zstd
 #include "../third_party/zstd/zstd.h"
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <sstream>
+#include <unordered_set>
 
 namespace CoopNet
 {
@@ -27,6 +30,37 @@ void EnsureCoopSaveDirs()
     {
         std::cerr << "Failed to create save directory " << kCoopSavePath << ": " << e.what() << std::endl;
     }
+}
+
+bool LoadCarParking(uint32_t sessionId, uint32_t peerId, CarParking& out)
+{
+    namespace fs = std::filesystem;
+    fs::path file =
+        fs::path(kCoopSavePath) / std::to_string(sessionId) / ("phase_" + std::to_string(peerId) + ".json.zst");
+    std::ifstream in(file, std::ios::binary);
+    if (!in.is_open())
+        return false;
+    std::string zdata((std::istreambuf_iterator<char>(in)), {});
+    std::vector<char> raw(2048);
+    size_t size = ZSTD_decompress(raw.data(), raw.size(), zdata.data(), zdata.size());
+    if (ZSTD_isError(size))
+        return false;
+    std::string json(raw.data(), size);
+    if (json.find("\"CarParking\"") == std::string::npos)
+        return false;
+    int parsed = std::sscanf(
+        json.c_str(), "{\"CarParking\":{\"vehTpl\":%u,\"pos\":[%f,%f,%f],\"rot\":[%f,%f,%f,%f],\"health\":%hu",
+        &out.vehTpl, &out.pos.X, &out.pos.Y, &out.pos.Z, &out.rot.X, &out.rot.Y, &out.rot.Z, &out.rot.W, &out.health);
+    return parsed >= 9;
+}
+
+void SaveCarParking(uint32_t sessionId, uint32_t peerId, const CarParking& cp)
+{
+    std::stringstream ss;
+    ss << "{\"CarParking\":{\"vehTpl\":" << cp.vehTpl << ",\"pos\":[" << cp.pos.X << ',' << cp.pos.Y << ',' << cp.pos.Z
+       << "],\"rot\":[" << cp.rot.X << ',' << cp.rot.Y << ',' << cp.rot.Z << ',' << cp.rot.W
+       << "],\"health\":" << cp.health << "}}";
+    SavePhase(sessionId, peerId, ss.str());
 }
 
 void SaveSession(uint32_t sessionId, const std::string& jsonBlob)
@@ -81,6 +115,57 @@ void SaveSession(uint32_t sessionId, const std::string& jsonBlob)
     catch (const std::exception& e)
     {
         std::cerr << "Error saving session: " << e.what() << std::endl;
+    }
+}
+
+void SavePhase(uint32_t sessionId, uint32_t peerId, const std::string& jsonBlob)
+{
+    try
+    {
+        EnsureCoopSaveDirs();
+        namespace fs = std::filesystem;
+        fs::path dir = fs::path(kCoopSavePath) / std::to_string(sessionId);
+        fs::create_directories(dir);
+        fs::path file = dir / ("phase_" + std::to_string(peerId) + ".json.zst");
+
+        std::vector<char> buf(ZSTD_compressBound(jsonBlob.size()));
+        size_t z = ZSTD_compress(buf.data(), buf.size(), jsonBlob.data(), jsonBlob.size(), 3);
+        if (ZSTD_isError(z))
+            z = 0;
+        buf.resize(z);
+
+        std::ofstream out(file, std::ios::binary | std::ios::trunc);
+        if (!out.is_open())
+        {
+            std::cerr << "Failed to open phase file " << file << std::endl;
+            return;
+        }
+        out.write(buf.data(), buf.size());
+        out.close();
+        if (out.good())
+        {
+            fs::path indexFile = dir / "phase_index.txt";
+            std::unordered_set<uint32_t> ids;
+            if (std::ifstream idxIn{indexFile}; idxIn.is_open())
+            {
+                uint32_t id;
+                while (idxIn >> id)
+                    ids.insert(id);
+            }
+            if (ids.insert(peerId).second)
+            {
+                std::ofstream idxOut(indexFile, std::ios::trunc);
+                if (idxOut.is_open())
+                {
+                    for (auto id : ids)
+                        idxOut << id << '\n';
+                }
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error saving phase: " << e.what() << std::endl;
     }
 }
 } // namespace CoopNet

--- a/cp2077-coop/src/core/SaveFork.hpp
+++ b/cp2077-coop/src/core/SaveFork.hpp
@@ -2,8 +2,10 @@
 
 // Utility functions that rewrite save file paths for co-op sessions.
 
-#include <string>
+#include <RED4ext/Scripting/Natives/Generated/Quaternion.hpp>
+#include <RED4ext/Scripting/Natives/Generated/Vector3.hpp>
 #include <cstdint>
+#include <string>
 
 namespace CoopNet
 {
@@ -12,4 +14,16 @@ constexpr const char* kCoopSavePath = "SavedGames/Coop/";
 std::string GetSessionSavePath(uint32_t sessionId);
 void EnsureCoopSaveDirs();
 void SaveSession(uint32_t sessionId, const std::string& jsonBlob);
-}
+void SavePhase(uint32_t sessionId, uint32_t peerId, const std::string& jsonBlob);
+
+struct CarParking
+{
+    uint32_t vehTpl = 0;
+    RED4ext::Vector3 pos{};
+    RED4ext::Quaternion rot{};
+    uint16_t health = 0;
+};
+
+bool LoadCarParking(uint32_t sessionId, uint32_t peerId, CarParking& out);
+void SaveCarParking(uint32_t sessionId, uint32_t peerId, const CarParking& cp);
+} // namespace CoopNet

--- a/cp2077-coop/src/core/SkillIds.hpp
+++ b/cp2077-coop/src/core/SkillIds.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdint>
+namespace CoopNet
+{
+enum class SkillId : uint16_t
+{
+    Athletics = 0,
+    Stealth,
+    Hacking,
+    Engineering,
+    Handguns,
+    Blades,
+    Assault,
+    Crafting,
+    Demolition,
+    Brawling,
+    ColdBlood,
+    CombatHacking,
+    Count
+};
+} // namespace CoopNet

--- a/cp2077-coop/src/gui/BusyOverlay.reds
+++ b/cp2077-coop/src/gui/BusyOverlay.reds
@@ -1,0 +1,28 @@
+public class BusyOverlay extends inkHUDLayer {
+    private static let s_instance: ref<BusyOverlay>;
+    private let label: ref<inkText>;
+
+    public static func Show(msg: String) -> Void {
+        if IsDefined(s_instance) { return; };
+        let hud = GameInstance.GetHUDManager(GetGame());
+        let o = new BusyOverlay();
+        o.label = new inkText();
+        o.label.SetStyle(n"bold 40px");
+        o.label.SetText(msg);
+        o.label.SetAnchor(inkEAnchor.Centered);
+        o.AddChild(o.label);
+        hud.AddLayer(o);
+        s_instance = o;
+        GameInstance.GetDelaySystem(GetGame()).DelayCallback(o, n"Hide", 3.0);
+    }
+
+    protected func Hide() -> Void {
+        let hud = GameInstance.GetHUDManager(GetGame());
+        hud.RemoveLayer(this);
+        s_instance = null;
+    }
+}
+
+public static func BusyOverlay_Show(msg: String) -> Void {
+    BusyOverlay.Show(msg);
+}

--- a/cp2077-coop/src/gui/CyberCooldownHud.reds
+++ b/cp2077-coop/src/gui/CyberCooldownHud.reds
@@ -3,6 +3,7 @@ public class CyberCooldownHud extends inkHUDLayer {
     private let canvas: ref<inkCanvas>;
     private let bars: array<ref<inkCircleProgress>>;
     private let times: array<Float>;
+    private let maxTimes: array<Float>;
 
     public static func Instance() -> ref<CyberCooldownHud> {
         if !IsDefined(s_instance) {
@@ -16,6 +17,7 @@ public class CyberCooldownHud extends inkHUDLayer {
         let inst = Instance();
         inst.EnsureUI(slot);
         inst.times[slot] = sec;
+        inst.maxTimes[slot] = sec;
         inst.bars[slot].SetValue(1.0);
     }
 
@@ -35,6 +37,7 @@ public class CyberCooldownHud extends inkHUDLayer {
             canvas.AddChild(bar);
             bars.Push(bar);
             times.Push(0.0);
+            maxTimes.Push(1.0);
         };
     }
 
@@ -45,13 +48,16 @@ public class CyberCooldownHud extends inkHUDLayer {
                 times[i] -= dt;
                 if times[i] <= 0.0 {
                     times[i] = 0.0;
-                    bars[i].SetTintColor(new HDRColor(0.2,1.0,0.2,1.0));
+                    bars[i].SetTintColor(new HDRColor(0.2, 1.0, 0.2, 1.0));
                     bars[i].SetValue(0.0);
                 } else {
-                    bars[i].SetValue(times[i] / MaxF(times[i], 0.001));
+                    let base = MaxF(maxTimes[i], 0.001);
+                    bars[i].SetValue((base - times[i]) / base);
+                    bars[i].SetTintColor(new HDRColor(0.4, 0.4, 0.4, 1.0));
                 };
             } else {
-                bars[i].SetTintColor(new HDRColor(0.2,1.0,0.2,1.0));
+                let pulse = (Sin(GameInstance.GetSimTime(GetGame()) * 4.0) + 1.0) * 0.5;
+                bars[i].SetTintColor(new HDRColor(0.1 + pulse * 0.3, 1.0, 0.1 + pulse * 0.3, 1.0));
             };
             i += 1;
         };

--- a/cp2077-coop/src/gui/EZEstate.reds
+++ b/cp2077-coop/src/gui/EZEstate.reds
@@ -1,0 +1,14 @@
+// Apartment permission UI helper.
+public class EZEstatePerms {
+    public static func AddPeer(apt: Uint32, peer: Uint32) -> Void {
+        Net_SendAptPermChange(apt, peer, true);
+    }
+
+    public static func RemovePeer(apt: Uint32, peer: Uint32) -> Void {
+        Net_SendAptPermChange(apt, peer, false);
+    }
+
+    public static func SetPublic(apt: Uint32, allow: Bool) -> Void {
+        Net_SendAptPermChange(apt, 0u, allow);
+    }
+}

--- a/cp2077-coop/src/net/Net.hpp
+++ b/cp2077-coop/src/net/Net.hpp
@@ -34,7 +34,8 @@ void Net_SendBreachInput(uint8_t index);
 void Net_BroadcastVehicleExplode(uint32_t vehicleId, uint32_t vfxId, uint32_t seed);
 void Net_BroadcastPartDetach(uint32_t vehicleId, uint8_t partId);
 void Net_BroadcastEject(uint32_t peerId, const RED4ext::Vector3& vel);
-void Net_BroadcastVehicleSpawn(uint32_t vehicleId, uint32_t archetypeId, uint32_t paintId, const TransformSnap& t);
+void Net_BroadcastVehicleSpawn(uint32_t vehicleId, uint32_t archetypeId, uint32_t paintId, uint32_t phaseId,
+                               const TransformSnap& t);
 void Net_SendSeatRequest(uint32_t vehicleId, uint8_t seatIdx);
 void Net_BroadcastSeatAssign(uint32_t peerId, uint32_t vehicleId, uint8_t seatIdx);
 void Net_SendVehicleHit(uint32_t vehicleId, uint16_t dmg, bool side);
@@ -91,6 +92,8 @@ void Net_SendPerkUnlock(uint32_t perkId, uint8_t rank);
 void Net_BroadcastPerkUnlock(uint32_t peerId, uint32_t perkId, uint8_t rank);
 void Net_SendPerkRespecRequest();
 void Net_SendPerkRespecAck(CoopNet::Connection* conn, uint16_t newPoints);
+void Net_SendSkillXP(uint16_t skillId, int16_t deltaXP);                       // SX-1
+void Net_BroadcastSkillXP(uint32_t peerId, uint16_t skillId, int16_t deltaXP); // SX-1
 void Net_BroadcastStatusApply(uint32_t targetId, uint8_t effectId, uint16_t durMs, uint8_t amp);
 void Net_BroadcastStatusTick(uint32_t targetId, int16_t hpDelta);
 void Net_BroadcastTrafficSeed(uint64_t sectorHash, uint64_t seed);
@@ -108,8 +111,9 @@ void Net_BroadcastPingOutline(uint32_t peerId, uint16_t durationMs, const std::v
 void Net_BroadcastLootRoll(uint32_t containerId, uint32_t seed);
 void Net_SendDealerBuy(uint32_t vehicleTpl, uint32_t price);
 void Net_BroadcastVehicleUnlock(uint32_t peerId, uint32_t vehicleTpl);
+void Net_BroadcastVehicleHitHighSpeed(uint32_t vehA, uint32_t vehB, const RED4ext::Vector3& delta);
 void Net_BroadcastWeaponInspect(uint32_t peerId, uint16_t animId);
-void Net_BroadcastFinisherStart(uint32_t actorId, uint32_t victimId, uint16_t animId);
+void Net_BroadcastFinisherStart(uint32_t actorId, uint32_t victimId, uint8_t finisherType);
 void Net_BroadcastFinisherEnd(uint32_t actorId);
 void Net_BroadcastTextureBiasChange(uint8_t bias);
 void Net_BroadcastCriticalVoteStart(uint32_t questHash);                                                 // PX-6
@@ -118,3 +122,34 @@ void Net_SendPhaseBundle(CoopNet::Connection* conn, uint32_t phaseId, const std:
 std::vector<uint32_t> QuestWatchdog_ListPhases();                                                        // PX-7 helper
 std::vector<uint8_t> BuildPhaseBundle(uint32_t phaseId);                                                 // PX-7
 void ApplyPhaseBundle(uint32_t phaseId, const uint8_t* buf, size_t len);                                 // PX-7
+void Net_SendAptPurchase(uint32_t aptId);
+void Net_SendAptEnterReq(uint32_t aptId, uint32_t ownerPhaseId);
+void Net_SendAptPermChange(uint32_t aptId, uint32_t targetPeerId, bool allow);
+void Net_BroadcastAptPermChange(uint32_t aptId, uint32_t targetPeerId, bool allow);
+void Net_SendAptPurchaseAck(CoopNet::Connection* conn, uint32_t aptId, bool success, uint64_t balance);
+void Net_SendAptEnterAck(CoopNet::Connection* conn, bool allow, uint32_t phaseId, uint32_t interiorSeed);
+void Net_SendVehicleTowRequest(const RED4ext::Vector3& pos);
+void Net_SendVehicleTowAck(CoopNet::Connection* conn, uint32_t ownerId, bool ok);
+void Net_SendReRollRequest(uint64_t itemId, uint32_t seed);                 // WM-1
+void Net_SendReRollResult(CoopNet::Connection* conn, const ItemSnap& snap); // WM-1
+void Net_SendRipperInstallRequest(uint8_t slotId);
+void Net_SendTileSelect(uint8_t row, uint8_t col);                // MG-1
+void Net_BroadcastTileGameStart(uint32_t phaseId, uint32_t seed); // MG-1
+void Net_BroadcastTileSelect(uint32_t peerId, uint32_t phaseId, uint8_t row,
+                             uint8_t col);                          // MG-1
+void Net_BroadcastShardProgress(uint32_t phaseId, uint8_t percent); // MG-2
+void Net_SendTradeInit(uint32_t targetPeerId);                      // TRD-1
+void Net_SendTradeOffer(const ItemSnap* items, uint8_t count,
+                        uint32_t eddies);                                                  // TRD-1
+void Net_SendTradeAccept(bool accept);                                                     // TRD-1
+void Net_BroadcastTradeFinalize(bool success);                                             // TRD-1
+void Net_BroadcastEndingVoteStart(uint32_t questHash);                                     // EG-1
+void Net_SendEndingVoteCast(bool yes);                                                     // EG-1
+void Net_BroadcastVehicleSnap(const VehicleSnap& snap);                                    // VT-1
+void Net_BroadcastTurretAim(uint32_t vehId, float yaw, float pitch);                       // VT-2
+void Net_BroadcastAirVehSpawn(uint32_t vehId, const RED4ext::Vector3* pts, uint8_t count); // VT-3
+void Net_BroadcastAirVehUpdate(uint32_t vehId, const TransformSnap& t);                    // VT-3
+void Net_BroadcastVehiclePaintChange(uint32_t vehId, uint32_t colorId, const char* plate); // VT-4
+void Net_BroadcastPanicEvent(const RED4ext::Vector3& pos, uint32_t seed);                  // AI-1
+void Net_BroadcastAIHack(uint32_t targetId, uint8_t effectId);                             // AI-2
+void Net_BroadcastBossPhase(uint32_t npcId, uint8_t phaseIdx);                             // AI-3

--- a/cp2077-coop/src/net/Packets.hpp
+++ b/cp2077-coop/src/net/Packets.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Snapshot.hpp"
+#include <RED4ext/Scripting/Natives/Generated/Vector3.hpp>
 #include <cstdint>
 
 namespace CoopNet
@@ -91,6 +92,7 @@ enum class EMsg : uint16_t
     PerkUnlock,
     PerkRespecRequest,
     PerkRespecAck,
+    SkillXP, // SX-1
     StatusApply,
     StatusTick,
     TrafficSeed,
@@ -113,7 +115,35 @@ enum class EMsg : uint16_t
     TextureBiasChange,
     CriticalVoteStart, // PX-6
     CriticalVoteCast,
-    PhaseBundle
+    PhaseBundle,
+    AptPurchase,
+    AptPurchaseAck,
+    AptEnterReq,
+    AptEnterAck,
+    AptPermChange,
+    VehicleHitHighSpeed,
+    VehicleTowRequest,
+    VehicleTowAck,
+    ReRollRequest, // WM-1
+    ReRollResult,
+    RipperInstallRequest,
+    TileGameStart, // MG-1
+    TileSelect,
+    ShardProgress, // MG-2
+    TradeInit,     // TRD-1
+    TradeOffer,
+    TradeAccept,
+    TradeFinalize,
+    EndingVoteStart, // EG-1
+    EndingVoteCast,
+    VehicleSnapshot, // VT-1
+    TurretAim,       // VT-2
+    AirVehSpawn,     // VT-3
+    AirVehUpdate,
+    VehiclePaintChange, // VT-4
+    PanicEvent,         // AI-1
+    AIHack,             // AI-2
+    BossPhase           // AI-3
 };
 
 struct PacketHeader
@@ -177,6 +207,7 @@ struct VehicleSpawnPacket
     uint32_t vehicleId;
     uint32_t archetypeId;
     uint32_t paintId;
+    uint32_t phaseId;
     TransformSnap transform;
 };
 
@@ -205,6 +236,13 @@ struct VehicleHitPacket
     uint16_t dmg;
     uint8_t side; // 1 if side impact
     uint8_t pad;
+};
+
+struct VehicleHitHighSpeedPacket
+{
+    uint32_t vehA;
+    uint32_t vehB;
+    RED4ext::Vector3 deltaVel;
 };
 
 struct WorldStatePacket
@@ -586,6 +624,13 @@ struct PerkRespecAckPacket
     uint8_t _pad[2];
 };
 
+struct SkillXPPacket
+{
+    uint32_t peerId;
+    uint16_t skillId;
+    int16_t deltaXP;
+};
+
 struct StatusApplyPacket
 {
     uint32_t targetId;
@@ -692,8 +737,8 @@ struct FinisherStartPacket
 {
     uint32_t actorId;
     uint32_t victimId;
-    uint16_t animId;
-    uint16_t _pad;
+    uint8_t finisherType;
+    uint8_t _pad[3];
 };
 
 struct FinisherEndPacket
@@ -724,6 +769,186 @@ struct PhaseBundlePacket
     uint32_t phaseId;
     uint16_t blobBytes;
     uint8_t zstdBlob[1];
+};
+
+struct AptPurchasePacket
+{
+    uint32_t aptId;
+};
+
+struct AptPurchaseAckPacket
+{
+    uint32_t aptId;
+    uint64_t balance;
+    uint8_t success;
+    uint8_t _pad[3];
+};
+
+struct AptEnterReqPacket
+{
+    uint32_t aptId;
+    uint32_t ownerPhaseId;
+};
+
+struct AptEnterAckPacket
+{
+    uint8_t allow;
+    uint8_t _pad[3];
+    uint32_t phaseId;
+    uint32_t interiorSeed;
+};
+
+struct AptPermChangePacket
+{
+    uint32_t aptId;
+    uint32_t targetPeerId;
+    uint8_t allow;
+    uint8_t _pad[3];
+};
+
+struct VehicleTowRequestPacket
+{
+    RED4ext::Vector3 pos;
+};
+
+struct VehicleTowAckPacket
+{
+    uint32_t ownerId;
+    uint8_t ok;
+    uint8_t _pad[3];
+};
+
+struct ReRollRequestPacket
+{
+    uint64_t itemId;
+    uint32_t seed;
+};
+
+struct ReRollResultPacket
+{
+    ItemSnap snap;
+};
+
+struct RipperInstallRequestPacket
+{
+    uint8_t slotId;
+    uint8_t _pad[3];
+};
+
+struct TileGameStartPacket
+{
+    uint32_t phaseId;
+    uint32_t seed;
+};
+
+struct TileSelectPacket
+{
+    uint32_t peerId;
+    uint32_t phaseId;
+    uint8_t row;
+    uint8_t col;
+    uint8_t _pad[2];
+};
+
+struct ShardProgressPacket
+{
+    uint32_t phaseId;
+    uint8_t percent;
+    uint8_t _pad[3];
+};
+
+struct TradeInitPacket
+{
+    uint32_t fromId;
+    uint32_t toId;
+};
+
+struct TradeOfferPacket
+{
+    uint32_t fromId;
+    uint32_t toId;
+    uint8_t count;
+    uint8_t _pad[3];
+    uint32_t eddies;
+    ItemSnap items[8];
+};
+
+struct TradeAcceptPacket
+{
+    uint32_t peerId;
+    uint8_t accept;
+    uint8_t _pad[3];
+};
+
+struct TradeFinalizePacket
+{
+    uint8_t success;
+    uint8_t _pad[3];
+};
+
+struct EndingVoteStartPacket
+{
+    uint32_t questHash;
+};
+
+struct EndingVoteCastPacket
+{
+    uint32_t peerId;
+    uint8_t yes;
+    uint8_t _pad[3];
+};
+
+struct VehicleSnapshotPacket
+{
+    VehicleSnap snap;
+};
+
+struct TurretAimPacket
+{
+    uint32_t vehId;
+    float yaw;
+    float pitch;
+};
+
+struct AirVehSpawnPacket
+{
+    uint32_t vehId;
+    uint8_t count;
+    uint8_t _pad[3];
+    RED4ext::Vector3 points[8];
+};
+
+struct AirVehUpdatePacket
+{
+    uint32_t vehId;
+    TransformSnap snap;
+};
+
+struct VehiclePaintChangePacket
+{
+    uint32_t vehId;
+    uint32_t colorId;
+    char plateId[8];
+};
+
+struct PanicEventPacket
+{
+    RED4ext::Vector3 pos;
+    uint32_t seed;
+};
+
+struct AIHackPacket
+{
+    uint32_t targetId;
+    uint8_t effectId;
+    uint8_t _pad[3];
+};
+
+struct BossPhasePacket
+{
+    uint32_t npcId;
+    uint8_t phaseIdx;
+    uint8_t _pad[3];
 };
 
 struct AvatarSpawnPacket

--- a/cp2077-coop/src/net/Snapshot.hpp
+++ b/cp2077-coop/src/net/Snapshot.hpp
@@ -109,6 +109,15 @@ struct ItemSnap
 static_assert(sizeof(ItemSnap) % 4 == 0, "ItemSnap must align to 4 bytes");
 static_assert(std::is_trivially_copyable_v<ItemSnap>, "ItemSnap must be trivial");
 
+// Vehicle state replicated from the server (VT-1)
+struct VehicleSnap
+{
+    TransformSnap transform;
+    float leanAngle; // bike tilt in degrees
+};
+static_assert(sizeof(VehicleSnap) % 4 == 0, "VehicleSnap must align to 4 bytes");
+static_assert(std::is_trivially_copyable_v<VehicleSnap>, "VehicleSnap must be trivial");
+
 // Writes snapshot data into a buffer with dirty-bit tracking.
 // Begin() resets internal state with the target header.
 // Write<T>() serializes a field and marks the bit in SnapshotFieldFlags.

--- a/cp2077-coop/src/net/SnapshotWriter.cpp
+++ b/cp2077-coop/src/net/SnapshotWriter.cpp
@@ -1,0 +1,30 @@
+#include "../runtime/QuestSync.reds"
+#include "../runtime/SpectatorCam.reds"
+#include "Snapshot.hpp"
+#include <vector>
+
+namespace CoopNet
+{
+struct EntitySnap
+{
+    uint32_t id;
+    uint32_t phaseId;
+    TransformSnap snap;
+};
+
+// Placeholder container of active entity snapshots
+extern std::vector<EntitySnap> g_entitySnaps;
+
+void BuildSnapshot(std::vector<EntitySnap>& out)
+{
+    uint32_t local = QuestSync::localPhase;
+    uint32_t spectate = SpectatorCam::spectatePhase;
+    for (auto& e : g_entitySnaps)
+    {
+        if (e.phaseId != local && e.phaseId != spectate)
+            continue; // PX-3
+        out.push_back(e);
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/physics/CarPhysics.cpp
+++ b/cp2077-coop/src/physics/CarPhysics.cpp
@@ -1,5 +1,7 @@
 #include "CarPhysics.hpp"
 #include "../core/GameClock.hpp"
+#include "../net/Net.hpp"
+#include <algorithm>
 #include <cmath>
 
 namespace CoopNet
@@ -45,5 +47,37 @@ void ClientPredict(TransformSnap& snap, float dtMs)
         float c = std::cosf(yaw * 0.5f);
         snap.rot = {0.f, 0.f, s, c};
     }
+}
+
+static float VecLen(const RED4ext::Vector3& v)
+{
+    return std::sqrt(v.X * v.X + v.Y * v.Y + v.Z * v.Z);
+}
+
+void HandleHighSpeedCollision(uint32_t idA, TransformSnap& a, float latencyAms, uint32_t idB, TransformSnap& b,
+                              float latencyBms)
+{
+    RED4ext::Vector3 diff = a.pos - b.pos;
+    float dist2 = diff.X * diff.X + diff.Y * diff.Y + diff.Z * diff.Z;
+    if (dist2 > 4.f)
+        return;
+
+    RED4ext::Vector3 rel = a.vel - b.vel;
+    float impactSpeed = VecLen(rel) * 3.6f; // m/s to km/h
+    if (impactSpeed < 200.f)
+        return;
+
+    float rewindMs = std::min({latencyAms, latencyBms, 50.f});
+    float dt = rewindMs / 1000.f;
+    RED4ext::Vector3 posA = a.pos - a.vel * dt;
+    RED4ext::Vector3 posB = b.pos - b.vel * dt;
+    diff = posA - posB;
+    if (diff.X * diff.X + diff.Y * diff.Y + diff.Z * diff.Z > 4.f)
+        return;
+
+    RED4ext::Vector3 delta = (b.vel - a.vel) * 0.5f;
+    a.vel += delta;
+    b.vel -= delta;
+    Net_BroadcastVehicleHitHighSpeed(idA, idB, delta);
 }
 } // namespace CoopNet

--- a/cp2077-coop/src/physics/CarPhysics.hpp
+++ b/cp2077-coop/src/physics/CarPhysics.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../net/Snapshot.hpp"
+#include <algorithm>
 
 namespace CoopNet
 {
@@ -10,4 +11,8 @@ void ServerSimulate(TransformSnap& inout, float dtMs);
 
 // Client-side prediction using the same integration step.
 void ClientPredict(TransformSnap& inout, float dtMs);
-}
+
+// High-speed collision resolution with latency rewind (VC-1)
+void HandleHighSpeedCollision(uint32_t idA, TransformSnap& a, float latencyAms, uint32_t idB, TransformSnap& b,
+                              float latencyBms);
+} // namespace CoopNet

--- a/cp2077-coop/src/runtime/AIHackSync.reds
+++ b/cp2077-coop/src/runtime/AIHackSync.reds
@@ -1,0 +1,16 @@
+public class AIHackSync {
+    public static func OnHack(target: Uint32, effectId: Uint8) -> Void {
+        LogChannel(n"aih", "target=" + IntToString(Cast<Int32>(target)));
+        StatusEffectSync.OnApply(target, effectId, 3000u, 1u);
+    }
+
+    public static func SendHack(target: Uint32, effectId: Uint8) -> Void {
+        if Net_IsAuthoritative() {
+            CoopNet.Net_BroadcastAIHack(target, effectId);
+        };
+    }
+}
+
+public static func AIHackSync_OnHack(id: Uint32, eff: Uint8) -> Void {
+    AIHackSync.OnHack(id, eff);
+}

--- a/cp2077-coop/src/runtime/AirVehicleProxy.reds
+++ b/cp2077-coop/src/runtime/AirVehicleProxy.reds
@@ -1,0 +1,29 @@
+public class AirVehicleProxy extends gameObject {
+    public var vehicleId: Uint32;
+    public var path: array<Vector3>;
+    public var idx: Int32;
+    public var state: TransformSnap;
+
+    public func Spawn(id: Uint32, points: array<Vector3>) -> Void {
+        vehicleId = id;
+        path = points;
+        idx = 0;
+    }
+
+    public func UpdateSnap(t: ref<TransformSnap>) -> Void {
+        state = t^;
+    }
+}
+
+public static func AirVehicleProxy_Spawn(id: Uint32, count: Uint8, points: ref<Vector3>) -> Void {
+    let p: array<Vector3>;
+    for i in 0u .. count {
+        p.PushBack(points[i]);
+    }
+    let av = new AirVehicleProxy();
+    av.Spawn(id, p);
+}
+
+public static func AirVehicleProxy_Update(id: Uint32, t: ref<TransformSnap>) -> Void {
+    // FIXME(next ticket): find proxy, update state
+}

--- a/cp2077-coop/src/runtime/Apartments.reds
+++ b/cp2077-coop/src/runtime/Apartments.reds
@@ -1,0 +1,26 @@
+public class Apartments {
+    public static func Purchase(aptId: Uint32) -> Void {
+        Net_SendAptPurchase(aptId);
+    }
+
+    public static func OnPurchaseAck(aptId: Uint32, success: Bool, bal: Uint64) -> Void {
+        if success {
+            CoopNotice.Show("Apartment purchased");
+        } else {
+            CoopNotice.Show("Purchase failed");
+        };
+        WalletHud.Update(Int64(bal));
+    }
+}
+
+public static func Apartments_OnPurchaseAck(aptId: Uint32, success: Bool, bal: Uint64) -> Void {
+    Apartments.OnPurchaseAck(aptId, success, bal);
+}
+
+public static func Apartments_OnEnterAck(allow: Bool, phaseId: Uint32, seed: Uint32) -> Void {
+    if allow {
+        CoopNotice.Show("Entered apartment");
+    } else {
+        CoopNotice.Show("Entry denied");
+    };
+}

--- a/cp2077-coop/src/runtime/AvatarProxy.reds
+++ b/cp2077-coop/src/runtime/AvatarProxy.reds
@@ -8,6 +8,8 @@ public class AvatarProxy extends gameObject {
     public var armor: Uint16;
     public var currentSector: Uint64;
     public var invulEndTick: Uint64;
+    public var meshId: Uint32;
+    public var tintId: Uint32;
     // Future tickets will push per-tick input states here for client prediction
     // and server reconciliation.
     // Buffered movement commands awaiting server acknowledgement.
@@ -77,8 +79,19 @@ public class AvatarProxy extends gameObject {
     public static func OnAppearance(id: Uint32, meshId: Uint32, tintId: Uint32) -> Void {
         let avatar = GameInstance.GetPlayerSystem(GetGame()).FindObject(id) as AvatarProxy;
         if IsDefined(avatar) {
-            LogChannel(n"appearance", "peer=" + IntToString(id) + " mesh=" + IntToString(meshId));
-            // TODO apply cloth mesh and tint
+            avatar.meshId = meshId;
+            avatar.tintId = tintId;
+            LogChannel(n"appearance", "peer=" + IntToString(id) + " mesh=" + IntToString(meshId) + " tint=" + IntToString(tintId));
+            avatar.RefreshAppearance();
+        };
+    }
+
+    public func RefreshAppearance() -> Void {
+        if HasMethod(this, n"SetBodyMesh") {
+            this.SetBodyMesh(meshId);
+        };
+        if HasMethod(this, n"SetBodyTint") {
+            this.SetBodyTint(tintId);
         };
     }
 

--- a/cp2077-coop/src/runtime/BossPhaseSync.reds
+++ b/cp2077-coop/src/runtime/BossPhaseSync.reds
@@ -1,0 +1,16 @@
+public class BossPhaseSync {
+    public static func OnSwitch(id: Uint32, phase: Uint8) -> Void {
+        LogChannel(n"boss", "npc=" + IntToString(Cast<Int32>(id)) + " phase=" + IntToString(Cast<Int32>(phase)));
+        // FIXME(next ticket): change mesh and behavior
+    }
+
+    public static func SendSwitch(id: Uint32, phase: Uint8) -> Void {
+        if Net_IsAuthoritative() {
+            CoopNet.Net_BroadcastBossPhase(id, phase);
+        };
+    }
+}
+
+public static func BossPhaseSync_OnSwitch(id: Uint32, phase: Uint8) -> Void {
+    BossPhaseSync.OnSwitch(id, phase);
+}

--- a/cp2077-coop/src/runtime/BraindancePatch.reds
+++ b/cp2077-coop/src/runtime/BraindancePatch.reds
@@ -1,0 +1,10 @@
+@wrapMethod(BDSystem)
+public final func EnterEditor() -> Void {
+    if !Net_IsAuthoritative() {
+        let timeSys = GameInstance.GetTimeSystem(GetGame());
+        timeSys.SetLocalTimeDilation(0.0);
+        CoopNet.Net_BroadcastCineStart(CoopNet.Fnv1a32("bd_editor"), 0u, Net_GetPeerId(), true);
+    } else {
+        wrappedMethod();
+    };
+}

--- a/cp2077-coop/src/runtime/CrimeSpawner.reds
+++ b/cp2077-coop/src/runtime/CrimeSpawner.reds
@@ -1,5 +1,31 @@
+public class CrimeTriggerVolume extends ScriptedTriggerBase {
+    private let triggered: Bool;
+
+    protected cb func OnEnter(instigator: ref<GameObject>) -> Bool {
+        if triggered { return false; };
+        if !Net_IsAuthoritative() { return false; };
+        triggered = true;
+        let name: String = NameToString(GetEntityName());
+        let eventId: Uint32 = CoopNet.Fnv1a32(name);
+        let seed: Uint32 = CoopNet.Fnv1a32(name + IntToString(Cast<Int32>(GameInstance.GetSimTime(GetGame()))));
+        var pkt: CoopNet.CrimeEventSpawnPacket;
+        pkt.eventId = eventId;
+        pkt.seed = seed;
+        pkt.count = 3u;
+        let base: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(GameInstance.GetSimTime(GetGame()))));
+        for i in range(0, 3) {
+            pkt.npcIds[i] = base + Cast<Uint32>(i);
+        };
+        CoopNet.Net_BroadcastCrimeEvent(pkt);
+        return true;
+    }
+}
+
 public class CrimeSpawner {
     public static func OnEvent(pkt: ref<CrimeEventSpawnPacket>) -> Void {
         LogChannel(n"ncpd", "Crime event id=" + IntToString(Cast<Int32>(pkt.eventId)));
+        for i in range(0, Cast<Int32>(pkt.count)) {
+            LogChannel(n"ncpd", "Spawn npc " + IntToString(Cast<Int32>(pkt.npcIds[i])));
+        };
     }
 }

--- a/cp2077-coop/src/runtime/CyberwareSync.reds
+++ b/cp2077-coop/src/runtime/CyberwareSync.reds
@@ -8,6 +8,7 @@ public class CyberwareSync {
         if peer == Net_GetLocalPeerId() {
             // Reload meshes for local player
             AvatarProxy.ReloadCyberware(slot);
+            CyberCooldownHud.SetCooldown(slot, 30.0);
         };
         QuickhackSync.RefreshSlots(peer);
     }

--- a/cp2077-coop/src/runtime/EZEstatesPatch.reds
+++ b/cp2077-coop/src/runtime/EZEstatesPatch.reds
@@ -1,0 +1,18 @@
+public static exec func CoopPurchaseApt(id: Int32) -> Void {
+    Apartments.Purchase(Cast<Uint32>(id));
+}
+
+public class EZEstatesOverlay extends inkHUDLayer {
+    private let view: ref<inkWebView>;
+    protected cb func OnCreate() -> Bool {
+        view = new inkWebView();
+        view.SetUrl("file://ezestates.html");
+        AddChild(view);
+        return true;
+    }
+}
+
+public static exec func ShowEzEstates() -> Void {
+    let hud = GameInstance.GetHUDManager(GetGame());
+    hud.AddLayer(new EZEstatesOverlay());
+}

--- a/cp2077-coop/src/runtime/FinisherPatch.reds
+++ b/cp2077-coop/src/runtime/FinisherPatch.reds
@@ -1,0 +1,28 @@
+@wrapMethod(FinisherSystem)
+public final func StartFinisher(actor: wref<GameObject>, victim: wref<GameObject>) -> Void {
+    wrappedMethod(actor, victim);
+    if Net_IsAuthoritative() {
+        let ts = GameInstance.GetTransactionSystem(GetGame());
+        let item: ItemID = ts.GetItemInSlot(actor, t"RightHand");
+        let type: gamedataItemCategory = RPGManager.GetItemCategory(ItemID.GetTDBID(item));
+        if type != gamedataItemCategory.Katana {
+            let ft: Uint8 = 0u;
+            switch type {
+                case gamedataItemCategory.Pistol:
+                    ft = 1u;
+                    break;
+                case gamedataItemCategory.Knife:
+                    ft = 2u;
+                    break;
+                case gamedataItemCategory.Revolver:
+                    ft = 3u;
+                    break;
+                default:
+                    ft = 0u;
+            };
+            if ft > 0u {
+                CoopNet.Net_BroadcastFinisherStart(EntityID.GetHash(actor.GetEntityID()), EntityID.GetHash(victim.GetEntityID()), ft);
+            };
+        };
+    };
+}

--- a/cp2077-coop/src/runtime/Inventory.reds
+++ b/cp2077-coop/src/runtime/Inventory.reds
@@ -40,6 +40,19 @@ public class Inventory {
         };
     }
 
+    public static func OnReRollResult(snap: ref<ItemSnap>) -> Void {
+        let count: Int32 = ArraySize(items);
+        var i: Int32 = 0;
+        while i < count {
+            if items[i].itemId == snap.itemId {
+                items[i] = *snap;
+                break;
+            };
+            i += 1;
+        };
+        LogChannel(n"DEBUG", "ReRolled " + Uint64ToString(snap.itemId));
+    }
+
     public static func OnPurchaseResult(itemId: Uint64, balance: Uint64, success: Bool) -> Void {
         if success {
             LogChannel(n"DEBUG", "Purchased item " + Uint64ToString(itemId));
@@ -55,6 +68,12 @@ public class Inventory {
 
     public static func RequestAttach(itemId: Uint64, slotIdx: Uint8, attachId: Uint64) -> Void {
         Net_SendAttachRequest(itemId, slotIdx, attachId);
+    }
+
+    public static func RequestReRoll(itemId: Uint64) -> Void {
+        let tick: Uint32 = CoopNet.GameClock.GetCurrentTick();
+        let seed: Uint32 = CoopNet.Fnv1a32(Uint64ToString(itemId) + IntToString(Cast<Int32>(tick)));
+        CoopNet.Net_SendReRollRequest(itemId, seed);
     }
 
     public static func RequestPurchase(vendorId: Uint32, itemId: Uint32, nonce: Uint64) -> Void {

--- a/cp2077-coop/src/runtime/LootRollPatch.reds
+++ b/cp2077-coop/src/runtime/LootRollPatch.reds
@@ -1,0 +1,7 @@
+public static exec func CoopContainerOpened(id: Int32) -> Void {
+    if !Net_IsAuthoritative() { return; };
+    let tick: Uint32 = CoopNet.GameClock.GetTime();
+    let pid: Uint32 = Net_GetPeerId();
+    let seed: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(tick)) + IntToString(id) + IntToString(Cast<Int32>(pid)));
+    CoopNet.Net_BroadcastLootRoll(Cast<Uint32>(id), seed);
+}

--- a/cp2077-coop/src/runtime/OutlineHelper.reds
+++ b/cp2077-coop/src/runtime/OutlineHelper.reds
@@ -1,0 +1,6 @@
+public class OutlineHelper {
+    public static func AddPing(id: Uint32, dur: Uint16) -> Void {
+        // Placeholder: hook engine outline later
+        LogChannel(n"ping", "outline " + IntToString(Cast<Int32>(id)) + " dur=" + IntToString(Cast<Int32>(dur)));
+    }
+}

--- a/cp2077-coop/src/runtime/PanicSync.reds
+++ b/cp2077-coop/src/runtime/PanicSync.reds
@@ -1,0 +1,22 @@
+public struct PanicEventPacket {
+    public let pos: Vector3;
+    public let seed: Uint32;
+}
+
+public class PanicSync {
+    public static func OnEvent(pos: Vector3, seed: Uint32) -> Void {
+        LogChannel(n"panic", "seed=" + IntToString(Cast<Int32>(seed)));
+        // FIXME(next ticket): spawn flee behavior
+    }
+
+    public static func SendEvent(pos: Vector3) -> Void {
+        if Net_IsAuthoritative() {
+            let s: Uint32 = CoopNet.Fnv1a32(FloatToString(pos.X) + FloatToString(pos.Y) + FloatToString(pos.Z) + IntToString(Cast<Int32>(CoopNet.GameClock.GetCurrentTick())));
+            CoopNet.Net_BroadcastPanicEvent(pos, s);
+        };
+    }
+}
+
+public static func PanicSync_OnEvent(pkt: ref<PanicEventPacket>) -> Void {
+    PanicSync.OnEvent(pkt.pos, pkt.seed);
+}

--- a/cp2077-coop/src/runtime/PhaseTrigger.reds
+++ b/cp2077-coop/src/runtime/PhaseTrigger.reds
@@ -3,8 +3,7 @@ public class PhaseTrigger {
 
   public static func SpawnPhaseTrigger(baseEntId: Uint32, phaseId: Uint32) -> Void {
     if !Net_IsAuthoritative() { return; };
-    let name: String = IntToString(Cast<Int32>(baseEntId)) + "_ph" + IntToString(Cast<Int32>(phaseId));
-    RED4ext.ExecuteFunction("TriggerSystem", "SpawnPhaseTrigger", null, baseEntId, phaseId, StringToName(name));
+    RED4ext.ExecuteFunction("TriggerSystem", "SpawnPhaseTrigger", null, baseEntId, phaseId);
     var list = spawned.Get(phaseId) as array<Uint32>;
     if !IsDefined(list) { list = []; };
     ArrayPush(list, baseEntId);

--- a/cp2077-coop/src/runtime/QuestTracker.reds
+++ b/cp2077-coop/src/runtime/QuestTracker.reds
@@ -1,0 +1,10 @@
+public class QuestTracker {
+    public static func ShowObjective(phaseId: Uint32, text: String) -> Void {
+        if phaseId != QuestSync.localPhase { return; };
+        CoopNotice.Show(text);
+    }
+}
+
+public static func QuestTracker_ShowObjective(phaseId: Uint32, text: String) -> Void {
+    QuestTracker.ShowObjective(phaseId, text);
+}

--- a/cp2077-coop/src/runtime/QuickhackSync.reds
+++ b/cp2077-coop/src/runtime/QuickhackSync.reds
@@ -99,7 +99,15 @@ public class QuickhackSync {
     }
 
     public static func OnPingOutline(peerId: Uint32, ids: array<Uint32>, dur: Uint16) -> Void {
-        for id in ids { LogChannel(n"ping", "outline " + IntToString(id)); };
+        for id in ids {
+            OutlineHelper.AddPing(id, dur);
+        };
+    }
+
+    public static func SendPingOutline(ids: array<Uint32>, dur: Uint16) -> Void {
+        if Net_IsAuthoritative() {
+            CoopNet.Net_BroadcastPingOutline(Net_GetPeerId(), dur, ids);
+        };
     }
 }
 

--- a/cp2077-coop/src/runtime/RipperdocPatch.reds
+++ b/cp2077-coop/src/runtime/RipperdocPatch.reds
@@ -1,0 +1,9 @@
+@wrapMethod(RipperdocSystem)
+public final func BeginInstall(slot: Int32) -> Void {
+    if Net_IsAuthoritative() {
+        wrappedMethod(slot);
+        CoopNet.Net_BroadcastCineStart(CoopNet.Fnv1a32("ripper_chair"), 0u, Net_GetPeerId(), true);
+    } else {
+        CoopNet.Net_SendRipperInstallRequest(Cast<Uint8>(slot));
+    };
+}

--- a/cp2077-coop/src/runtime/SkillSync.reds
+++ b/cp2077-coop/src/runtime/SkillSync.reds
@@ -1,0 +1,16 @@
+public class SkillSync {
+    public static func RequestXP(id: Uint16, delta: Int16) -> Void {
+        CoopNet.Net_SendSkillXP(id, delta);
+    }
+
+    public static func OnXP(peerId: Uint32, id: Uint16, delta: Int16) -> Void {
+        let sys = GameInstance.GetScriptableSystemsContainer(GetGame()).Get(n"StatsSystem") as StatsSystem;
+        if IsDefined(sys) {
+            RED4ext.ExecuteFunction(sys, n"AddSkillXP", Cast<gamedataProficiencyType>(id), Cast<Float>(delta), 0, null);
+        };
+    }
+}
+
+public static func SkillSync_OnXP(peer: Uint32, id: Uint16, delta: Int16) -> Void {
+    SkillSync.OnXP(peer, id, delta);
+}

--- a/cp2077-coop/src/runtime/SkillXPPatch.reds
+++ b/cp2077-coop/src/runtime/SkillXPPatch.reds
@@ -1,0 +1,8 @@
+@wrapMethod(StatsSystem)
+public final func AddSkillXP(skill: gamedataProficiencyType, amount: Float, reason: Int32, owner: wref<GameObject>) -> Void {
+    if Net_IsAuthoritative() {
+        wrappedMethod(skill, amount, reason, owner);
+    } else {
+        SkillSync.RequestXP(Cast<Uint16>(skill), Cast<Int16>(RoundF(amount)));
+    };
+}

--- a/cp2077-coop/src/runtime/SpectatorCam.reds
+++ b/cp2077-coop/src/runtime/SpectatorCam.reds
@@ -6,6 +6,7 @@ public class SpectatorCam {
     private static let blend: Float;
     private static let blendPos: Vector3;
     private static let blendRot: Quaternion;
+    public static var spectatePhase: Uint32 = QuestSync.localPhase;
     // Switches the local player into spectator mode and disables standard HUD.
     public static func Enter(peerId: Uint32) -> Void {
         GameModeManager.current = GameModeManager.GameMode.Spectate;
@@ -105,6 +106,21 @@ public class SpectatorCam {
 // Console command: /spectate <peerId>
 public static exec func Spectate(peerId: Int32) -> Void {
     Net_SendSpectateRequest(Cast<Uint32>(peerId));
+}
+
+// Console command: /assist <peerId|off>
+public static exec func Assist(arg: String) -> Void {
+    let player = GameInstance.GetPlayerSystem(GetGame()).GetLocalPlayerMainGameObject();
+    if IsDefined(player) && HasMethod(player, n"IsInCombat") {
+        if player.IsInCombat() { return; };
+    };
+    if arg == "off" {
+        spectatePhase = QuestSync.localPhase;
+    } else {
+        let id = StringToInt(arg);
+        spectatePhase = Cast<Uint32>(id);
+        CoopNotice.Show("Assisting " + arg);
+    };
 }
 
 public static func SpectatorCam_Enter(peerId: Uint32) -> Void {

--- a/cp2077-coop/src/runtime/TileGameSync.reds
+++ b/cp2077-coop/src/runtime/TileGameSync.reds
@@ -1,0 +1,36 @@
+public class TileGameSync {
+    public static func OnStart(phase: Uint32, seed: Uint32) -> Void {
+        LogChannel(n"DEBUG", "TileGameStart phase=" + IntToString(Cast<Int32>(phase)));
+        if phase != QuestSync.localPhase && phase != SpectatorCam.spectatePhase { return; };
+        let hud = new BreachHud();
+        hud.Start(Net_GetPeerId(), seed, 5u, 5u);
+    }
+
+    public static func OnSelect(peer: Uint32, row: Uint8, col: Uint8) -> Void {
+        LogChannel(n"DEBUG", "TileSelect peer=" + IntToString(Cast<Int32>(peer)));
+    }
+
+    public static func OnProgress(p: Uint8) -> Void {
+        LogChannel(n"DEBUG", "ShardProgress=" + IntToString(Cast<Int32>(p)));
+    }
+
+    public static func SendSelect(row: Uint8, col: Uint8) -> Void {
+        if Net_IsAuthoritative() {
+            CoopNet.Net_BroadcastTileSelect(Net_GetPeerId(), QuestSync.localPhase, row, col);
+        } else {
+            CoopNet.Net_SendTileSelect(row, col);
+        };
+    }
+}
+
+public static func TileGameSync_OnStart(ph: Uint32, seed: Uint32) -> Void {
+    TileGameSync.OnStart(ph, seed);
+}
+
+public static func TileGameSync_OnSelect(peer: Uint32, row: Uint8, col: Uint8) -> Void {
+    TileGameSync.OnSelect(peer, row, col);
+}
+
+public static func TileGameSync_OnProgress(p: Uint8) -> Void {
+    TileGameSync.OnProgress(p);
+}

--- a/cp2077-coop/src/runtime/TradeWindow.reds
+++ b/cp2077-coop/src/runtime/TradeWindow.reds
@@ -1,0 +1,40 @@
+public class TradeWindow extends inkHUDLayer {
+    private static let s_instance: ref<TradeWindow>;
+    public static exec func Trade(peer: Int32) -> Void {
+        CoopNotice.Show("Opening trade");
+        CoopNet.Net_SendTradeInit(Cast<Uint32>(peer));
+    }
+    public static func OnInit(from: Uint32) -> Void {
+        if IsDefined(s_instance) { return; };
+        let hud = GameInstance.GetHUDManager(GetGame());
+        s_instance = new TradeWindow();
+        hud.AddLayer(s_instance);
+    }
+    public static func OnOffer(from: Uint32, items: script_ref<array<ItemSnap>>, count: Uint8, eddies: Uint32) -> Void {
+        LogChannel(n"trade", "offer from=" + IntToString(Cast<Int32>(from)));
+    }
+    public static func OnAccept(peer: Uint32, ok: Bool) -> Void {
+        LogChannel(n"trade", "accept from=" + IntToString(Cast<Int32>(peer)));
+    }
+    public static func OnFinalize(ok: Bool) -> Void {
+        CoopNotice.Show("Trade " + (ok ? "complete" : "cancelled"));
+        if IsDefined(s_instance) {
+            let hud = GameInstance.GetHUDManager(GetGame());
+            hud.RemoveLayer(s_instance);
+            s_instance = null;
+        };
+    }
+}
+
+public static func TradeWindow_OnInit(peer: Uint32) -> Void {
+    TradeWindow.OnInit(peer);
+}
+public static func TradeWindow_OnOffer(from: Uint32, items: script_ref<array<ItemSnap>>, count: Uint8, eddies: Uint32) -> Void {
+    TradeWindow.OnOffer(from, items, count, eddies);
+}
+public static func TradeWindow_OnAccept(p: Uint32, ok: Bool) -> Void {
+    TradeWindow.OnAccept(p, ok);
+}
+public static func TradeWindow_OnFinalize(ok: Bool) -> Void {
+    TradeWindow.OnFinalize(ok);
+}

--- a/cp2077-coop/src/runtime/VehicleSummonSync.reds
+++ b/cp2077-coop/src/runtime/VehicleSummonSync.reds
@@ -1,6 +1,6 @@
 public class VehicleSummonSync {
     public static func OnSummon(pkt: ref<VehicleSummonPacket>) -> Void {
-        VehicleProxy_Spawn(pkt^.vehId, &pkt^.pos);
+        VehicleProxy_Spawn(pkt^.vehId, &pkt^.pos, 0u);
     }
 }
 

--- a/cp2077-coop/src/runtime/WeaponSync.reds
+++ b/cp2077-coop/src/runtime/WeaponSync.reds
@@ -9,7 +9,7 @@ public class WeaponSync {
         };
     }
 
-    public static func OnFinisherStart(actor: Uint32, victim: Uint32, anim: Uint16) -> Void {
+    public static func OnFinisherStart(actor: Uint32, victim: Uint32, ft: Uint8) -> Void {
         LogChannel(n"weapon", "Finisher start actor=" + IntToString(Cast<Int32>(actor)));
     }
 
@@ -22,8 +22,8 @@ public static func WeaponSync_OnInspect(peer: Uint32, anim: Uint16) -> Void {
     WeaponSync.OnInspect(peer, anim);
 }
 
-public static func WeaponSync_OnFinisherStart(actor: Uint32, victim: Uint32, anim: Uint16) -> Void {
-    WeaponSync.OnFinisherStart(actor, victim, anim);
+public static func WeaponSync_OnFinisherStart(actor: Uint32, victim: Uint32, ft: Uint8) -> Void {
+    WeaponSync.OnFinisherStart(actor, victim, ft);
 }
 
 public static func WeaponSync_OnFinisherEnd(actor: Uint32) -> Void {

--- a/cp2077-coop/src/runtime/WorkTablePatch.reds
+++ b/cp2077-coop/src/runtime/WorkTablePatch.reds
@@ -1,0 +1,8 @@
+@wrapMethod(WorkTable)
+public final func ReRollMods(itemId: Uint64) -> Void {
+    if Net_IsAuthoritative() {
+        wrappedMethod(itemId);
+    } else {
+        Inventory.RequestReRoll(itemId);
+    };
+}

--- a/cp2077-coop/src/server/ApartmentController.cpp
+++ b/cp2077-coop/src/server/ApartmentController.cpp
@@ -1,0 +1,180 @@
+#include "ApartmentController.hpp"
+#include "../core/SaveFork.hpp"
+#include "../core/SessionState.hpp"
+#include "../net/Net.hpp"
+#include "LedgerService.hpp"
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace CoopNet
+{
+struct AptInfo
+{
+    float x;
+    float y;
+    float z;
+    uint32_t price;
+    std::string interiorScene;
+    uint32_t extDoorId;
+};
+static std::unordered_map<uint32_t, AptInfo> g_info;
+static std::unordered_map<uint32_t, std::unordered_set<uint32_t>> g_owned;
+static std::unordered_map<uint32_t, bool> g_loaded;
+struct PermInfo
+{
+    bool pub = false;
+    std::unordered_set<uint32_t> peers;
+};
+static std::unordered_map<uint32_t, PermInfo> g_perms;
+
+void ApartmentController_Load()
+{
+    std::ifstream in("Apartments.csv");
+    if (!in.is_open())
+        return;
+    std::string line;
+    std::getline(in, line); // header
+    while (std::getline(in, line))
+    {
+        std::stringstream ss(line);
+        std::string tok;
+        AptInfo info{};
+        uint32_t id = 0;
+        for (int i = 0; std::getline(ss, tok, ','); ++i)
+        {
+            switch (i)
+            {
+            case 0:
+                id = static_cast<uint32_t>(std::stoul(tok));
+                break;
+            case 1:
+                info.x = std::stof(tok);
+                break;
+            case 2:
+                info.y = std::stof(tok);
+                break;
+            case 3:
+                info.z = std::stof(tok);
+                break;
+            case 4:
+                info.price = static_cast<uint32_t>(std::stoul(tok));
+                break;
+            case 5:
+                info.interiorScene = tok;
+                break;
+            case 6:
+                info.extDoorId = static_cast<uint32_t>(std::stoul(tok));
+                break;
+            default:
+                break;
+            }
+        }
+        g_info[id] = info;
+    }
+    std::cout << "[Apt] loaded " << g_info.size() << " entries" << std::endl;
+}
+
+void ApartmentController_HandlePurchase(Connection* conn, uint32_t aptId)
+{
+    auto it = g_info.find(aptId);
+    if (it == g_info.end() || !conn)
+        return;
+    uint64_t bal;
+    if (!Ledger_Transfer(conn, -static_cast<int64_t>(it->second.price), 0, bal))
+    {
+        Net_SendAptPurchaseAck(conn, aptId, false, conn->balance);
+        return;
+    }
+    g_owned[conn->peerId].insert(aptId);
+    std::stringstream ss;
+    ss << "{\"ApartmentOwnership\":[";
+    bool first = true;
+    for (auto id : g_owned[conn->peerId])
+    {
+        if (!first)
+            ss << ',';
+        ss << "{\"aptId\":" << id << ",\"owner\":" << conn->peerId << '}';
+        first = false;
+    }
+    ss << "]}";
+    SavePhase(SessionState_GetId(), conn->peerId, ss.str());
+    Net_SendAptPurchaseAck(conn, aptId, true, bal);
+}
+
+const AptInfo* ApartmentController_GetInfo(uint32_t aptId)
+{
+    auto it = g_info.find(aptId);
+    if (it == g_info.end())
+        return nullptr;
+    return &it->second;
+}
+
+bool ApartmentController_IsOwned(uint32_t peerId, uint32_t aptId)
+{
+    auto it = g_owned.find(peerId);
+    if (it == g_owned.end())
+        return false;
+    return it->second.find(aptId) != it->second.end();
+}
+
+void ApartmentController_HandleEnter(Connection* conn, uint32_t aptId, uint32_t ownerPhaseId)
+{
+    if (!conn)
+        return;
+    auto infoIt = g_info.find(aptId);
+    if (infoIt == g_info.end())
+    {
+        Net_SendAptEnterAck(conn, false, 0, 0);
+        return;
+    }
+    if (!ApartmentController_IsOwned(ownerPhaseId, aptId))
+    {
+        Net_SendAptEnterAck(conn, false, 0, 0);
+        return;
+    }
+    if (conn->peerId != ownerPhaseId)
+    {
+        auto permIt = g_perms.find(aptId);
+        bool allowed = permIt != g_perms.end() && (permIt->second.pub || permIt->second.peers.count(conn->peerId));
+        if (!allowed)
+        {
+            Net_SendAptEnterAck(conn, false, 0, 0);
+            return;
+        }
+    }
+
+    if (!g_loaded[ownerPhaseId])
+    {
+        // Interior scenes stream on demand per owner phase
+        g_loaded[ownerPhaseId] = true;
+    }
+
+    uint32_t seed = static_cast<uint32_t>(std::hash<std::string>{}(infoIt->second.interiorScene) ^ ownerPhaseId);
+    Net_SendAptEnterAck(conn, true, ownerPhaseId, seed);
+}
+
+void ApartmentController_HandlePermChange(Connection* conn, uint32_t aptId, uint32_t targetPeerId, bool allow)
+{
+    if (!conn || !ApartmentController_IsOwned(conn->peerId, aptId))
+        return;
+    PermInfo& p = g_perms[aptId];
+    if (targetPeerId == 0)
+    {
+        p.pub = allow;
+    }
+    else if (allow)
+    {
+        p.peers.insert(targetPeerId);
+    }
+    else
+    {
+        p.peers.erase(targetPeerId);
+    }
+    AptPermChangePacket pkt{aptId, targetPeerId, static_cast<uint8_t>(allow), {0, 0, 0}};
+    Net_Broadcast(EMsg::AptPermChange, &pkt, sizeof(pkt));
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/ApartmentController.hpp
+++ b/cp2077-coop/src/server/ApartmentController.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "../net/Connection.hpp"
+
+namespace CoopNet
+{
+struct AptInfo;
+void ApartmentController_Load();
+void ApartmentController_HandlePurchase(Connection* conn, uint32_t aptId);
+const AptInfo* ApartmentController_GetInfo(uint32_t aptId);
+bool ApartmentController_IsOwned(uint32_t peerId, uint32_t aptId);
+void ApartmentController_HandleEnter(Connection* conn, uint32_t aptId, uint32_t ownerPhaseId);
+void ApartmentController_HandlePermChange(Connection* conn, uint32_t aptId, uint32_t targetPeerId, bool allow);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/DamageValidator.cpp
+++ b/cp2077-coop/src/server/DamageValidator.cpp
@@ -13,6 +13,8 @@ uint16_t FilterDamage(uint32_t sourcePeer, uint32_t targetPeer, bool targetIsNpc
         return 0;
 
     float mult = PerkController_GetHealthMult(targetPeer);
+    if (PerkController_HasRelic(sourcePeer, 1000)) // Data Tunneling
+        rawDmg = static_cast<uint16_t>(static_cast<float>(rawDmg) * 1.1f);
     uint16_t maxAllowed = static_cast<uint16_t>((targetArmor * 4 + 200) * mult);
     if (rawDmg > maxAllowed)
     {

--- a/cp2077-coop/src/server/DedicatedMain.cpp
+++ b/cp2077-coop/src/server/DedicatedMain.cpp
@@ -1,13 +1,16 @@
 #include "../core/GameClock.hpp"
+#include "../core/SaveFork.hpp"
 #include "../core/SaveMigration.hpp"
 #include "../core/SessionState.hpp"
 #include "../net/Net.hpp"
 #include "AdminController.hpp"
+#include "ApartmentController.hpp"
 #include "BreachController.hpp"
 #include "ElevatorController.hpp"
 #include "GlobalEventController.hpp"
 #include "Heartbeat.hpp"
 #include "NpcController.hpp"
+#include "PhaseGC.hpp"
 #include "PoliceDispatch.hpp"
 #include "ServerConfig.hpp"
 #include "SnapshotHeap.hpp"
@@ -32,11 +35,24 @@ int main(int argc, char** argv)
     }
 
     CoopNet::ServerConfig_Load();
+    CoopNet::ApartmentController_Load();
     CoopNet::QuestWatchdog_LoadCritical();
+    CoopNet::QuestWatchdog_LoadRomance();
     Net_Init();
     CoopNet::MigrateSinglePlayerSave();
+    CoopNet::CarParking park{};
     CoopNet::TransformSnap vs{{0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 1.f}, {0.f, 0.f, 0.f}};
-    CoopNet::VehicleController_Spawn(CoopNet::Fnv1a32("vehicle_caliburn"), 0u, vs);
+    if (CoopNet::LoadCarParking(CoopNet::SessionState_GetId(), 1u, park) && park.health > 0)
+    {
+        vs.pos = park.pos;
+        vs.rot = park.rot;
+        vs.health = park.health;
+        CoopNet::VehicleController_SpawnPhaseVehicle(park.vehTpl, 0u, vs, 0u);
+    }
+    else
+    {
+        CoopNet::VehicleController_SpawnPhaseVehicle(CoopNet::Fnv1a32("vehicle_caliburn"), 0u, vs, 0u);
+    }
     CoopNet::WebDash_Start();
     CoopNet::AdminController_Start();
     std::cout << "Dedicated up" << std::endl;
@@ -94,6 +110,7 @@ int main(int argc, char** argv)
             CoopNet::NpcController_ServerTick(tickMs);
             CoopNet::VehicleController_ServerTick(tickMs);
             CoopNet::BreachController_ServerTick(tickMs);
+            CoopNet::ShardController_ServerTick(tickMs);
             CoopNet::VendorController_Tick(tickMs);
             CoopNet::PoliceDispatch_Tick(tickMs);
             CoopNet::StatusController_Tick(tickMs);
@@ -102,6 +119,7 @@ int main(int argc, char** argv)
         }
         Net_Poll(static_cast<uint32_t>(tickMs));
         CoopNet::QuestWatchdog_Tick(tickMs);
+        CoopNet::PhaseGC_Tick(CoopNet::GameClock::GetCurrentTick());
         CoopNet::AdminController_PollCommands();
         hbTimer += tickMs / 1000.f;
         memTimer += tickMs / 1000.f;

--- a/cp2077-coop/src/server/InventoryController.hpp
+++ b/cp2077-coop/src/server/InventoryController.hpp
@@ -7,6 +7,7 @@ namespace CoopNet
 
 void Inventory_HandleCraftRequest(Connection* conn, uint32_t recipeId);
 void Inventory_HandleAttachRequest(Connection* conn, uint64_t itemId, uint8_t slotIdx, uint64_t attachmentId);
+void Inventory_HandleReRollRequest(Connection* conn, uint64_t itemId, uint32_t seed); // WM-1
 ItemSnap Inventory_CreateItem(uint16_t tpl, uint32_t ownerId);
 
 } // namespace CoopNet

--- a/cp2077-coop/src/server/PerkController.hpp
+++ b/cp2077-coop/src/server/PerkController.hpp
@@ -7,4 +7,5 @@ namespace CoopNet
 void PerkController_HandleUnlock(Connection* conn, uint32_t perkId, uint8_t rank);
 void PerkController_HandleRespec(Connection* conn);
 float PerkController_GetHealthMult(uint32_t peerId);
+bool PerkController_HasRelic(uint32_t peerId, uint32_t perkId); // SX-2
 } // namespace CoopNet

--- a/cp2077-coop/src/server/PhaseGC.cpp
+++ b/cp2077-coop/src/server/PhaseGC.cpp
@@ -1,0 +1,57 @@
+#include "PhaseGC.hpp"
+#include "../core/GameClock.hpp"
+#include "../net/Net.hpp"
+#include "NpcController.hpp"
+#include "PhaseTriggerController.hpp"
+#include "SnapshotHeap.hpp"
+#include <RED4ext/RED4ext.hpp>
+#include <iostream>
+#include <unordered_map>
+
+namespace CoopNet
+{
+
+static std::unordered_map<uint32_t, uint64_t> g_lastActive;
+
+void PhaseGC_Touch(uint32_t phaseId)
+{
+    g_lastActive[phaseId] = GameClock::GetCurrentTick();
+}
+
+void PhaseGC_Tick(uint64_t nowTick)
+{
+    const uint64_t timeout = static_cast<uint64_t>(600000.0f / GameClock::GetTickMs());
+    auto conns = Net_GetConnections();
+    for (auto it = g_lastActive.begin(); it != g_lastActive.end();)
+    {
+        uint32_t id = it->first;
+        if (id == 0)
+        {
+            ++it;
+            continue;
+        }
+        bool hasPlayer = false;
+        for (auto* c : conns)
+        {
+            if (c->peerId == id)
+            {
+                hasPlayer = true;
+                break;
+            }
+        }
+        if (!hasPlayer && nowTick - it->second > timeout)
+        {
+            PhaseTrigger_Clear(id);
+            NpcController_Despawn(id); // best-effort per-phase cleanup
+            SnapshotStore_PurgeOld(0.f);
+            std::cout << "[PhaseGC] cleaned phase " << id << std::endl;
+            it = g_lastActive.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/PhaseGC.hpp
+++ b/cp2077-coop/src/server/PhaseGC.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+namespace CoopNet
+{
+void PhaseGC_Touch(uint32_t phaseId);
+void PhaseGC_Tick(uint64_t nowTickMs);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/PhaseTriggerController.cpp
+++ b/cp2077-coop/src/server/PhaseTriggerController.cpp
@@ -1,0 +1,28 @@
+#include "PhaseTriggerController.hpp"
+#include <RED4ext/RED4ext.hpp>
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+
+namespace CoopNet
+{
+
+static std::unordered_map<uint32_t, std::vector<uint32_t>> g_phaseTriggerIds;
+
+void PhaseTrigger_Spawn(uint32_t baseEntId, uint32_t phaseId)
+{
+    RED4ext::ExecuteFunction("TriggerSystem", "SpawnPhaseTrigger", nullptr, baseEntId, phaseId);
+    g_phaseTriggerIds[phaseId].push_back(baseEntId);
+}
+
+void PhaseTrigger_Clear(uint32_t phaseId)
+{
+    auto it = g_phaseTriggerIds.find(phaseId);
+    if (it == g_phaseTriggerIds.end())
+        return;
+    for (uint32_t id : it->second)
+        RED4ext::ExecuteFunction("TriggerSystem", "DestroyTrigger", nullptr, id);
+    g_phaseTriggerIds.erase(it);
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/PhaseTriggerController.hpp
+++ b/cp2077-coop/src/server/PhaseTriggerController.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet
+{
+void PhaseTrigger_Spawn(uint32_t baseEntId, uint32_t phaseId);
+void PhaseTrigger_Clear(uint32_t phaseId);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/QuestWatchdog.cpp
+++ b/cp2077-coop/src/server/QuestWatchdog.cpp
@@ -1,5 +1,8 @@
 #include "QuestWatchdog.hpp"
+#include "../core/Hash.hpp"
 #include "../net/Net.hpp"
+#include "PhaseGC.hpp"
+#include "PhaseTriggerController.hpp"
 #include <fstream>
 #include <unordered_map>
 
@@ -11,11 +14,45 @@ static std::unordered_map<uint32_t, float> g_diverge;
 static float g_timer = 0.f;
 static uint32_t g_resyncCount = 0;
 static float g_window = 0.f;
-static std::unordered_map<uint32_t, uint16_t> g_critical; // PX-6
+static std::unordered_map<uint32_t, uint16_t> g_critical;                              // PX-6
+static std::unordered_map<uint32_t, std::unordered_map<uint16_t, uint32_t>> g_romance; // RM-1
+static bool g_voteActive = false;
+static uint32_t g_voteQuest = 0;
+static uint32_t g_votePhase = 0;
+static float g_voteTimer = 0.f;
+static std::unordered_map<uint32_t, bool> g_voteCast;
+static bool g_endVoteActive = false; // EG-1
+static float g_endVoteTimer = 0.f;
+static std::unordered_map<uint32_t, bool> g_endVoteCast;
 
 void QuestWatchdog_Record(uint32_t phaseId, uint32_t questHash, uint16_t stage)
 {
     g_phaseStages[phaseId][questHash] = stage;
+    PhaseGC_Touch(phaseId);
+    auto r = g_romance.find(questHash);
+    if (r != g_romance.end())
+    {
+        auto stIt = r->second.find(stage);
+        if (stIt != r->second.end())
+            Net_BroadcastCineStart(stIt->second, 0u, phaseId, true);
+    }
+    auto crit = g_critical.find(questHash);
+    if (crit != g_critical.end() && stage >= crit->second && !g_voteActive)
+    {
+        g_voteActive = true;
+        g_voteQuest = questHash;
+        g_votePhase = phaseId;
+        g_voteTimer = 30.f;
+        g_voteCast.clear();
+        Net_BroadcastCriticalVoteStart(questHash);
+    }
+    if (questHash == 0xaa573886 && stage >= 1000 && !g_endVoteActive)
+    {
+        g_endVoteActive = true;
+        g_endVoteTimer = 30.f;
+        g_endVoteCast.clear();
+        Net_BroadcastEndingVoteStart(questHash);
+    }
 }
 
 void QuestWatchdog_BuildFullSync(uint32_t phaseId, QuestFullSyncPacket& outPkt)
@@ -42,25 +79,135 @@ std::vector<uint32_t> QuestWatchdog_ListPhases()
     return ids;
 }
 
+void QuestWatchdog_HandleVote(uint32_t peerId, bool yes)
+{
+    if (!g_voteActive)
+        return;
+    g_voteCast[peerId] = yes;
+}
+
+void QuestWatchdog_HandleEndingVote(uint32_t peerId, bool yes)
+{
+    if (!g_endVoteActive)
+        return;
+    g_endVoteCast[peerId] = yes;
+}
+
 void QuestWatchdog_LoadCritical()
 {
     std::ifstream in("CriticalQuests.json");
     if (!in.is_open())
         return;
-    std::string line;
-    while (std::getline(in, line))
+    std::string json((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    size_t pos = 0;
+    while (true)
     {
-        size_t comma = line.find(',');
-        if (comma == std::string::npos)
-            continue;
-        uint32_t q = std::stoul(line.substr(0, comma));
-        uint16_t st = static_cast<uint16_t>(std::stoi(line.substr(comma + 1)));
+        pos = json.find("\"questHash\"", pos);
+        if (pos == std::string::npos)
+            break;
+        pos = json.find(':', pos);
+        size_t s = json.find_first_of("0123456789", pos);
+        size_t e = json.find_first_not_of("0123456789", s);
+        uint32_t q = std::stoul(json.substr(s, e - s));
+        pos = json.find("\"stage\"", pos);
+        pos = json.find(':', pos);
+        s = json.find_first_of("0123456789", pos);
+        e = json.find_first_not_of("0123456789", s);
+        uint16_t st = static_cast<uint16_t>(std::stoi(json.substr(s, e - s)));
         g_critical[q] = st;
+    }
+}
+
+void QuestWatchdog_LoadRomance()
+{
+    std::ifstream in("RomanceScenes.json");
+    if (!in.is_open())
+        return;
+    std::string json((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    size_t pos = 0;
+    while (true)
+    {
+        pos = json.find("\"questHash\"", pos);
+        if (pos == std::string::npos)
+            break;
+        pos = json.find(':', pos);
+        size_t s = json.find_first_of("0123456789", pos);
+        size_t e = json.find_first_not_of("0123456789", s);
+        uint32_t q = std::stoul(json.substr(s, e - s));
+        pos = json.find("\"stage\"", pos);
+        pos = json.find(':', pos);
+        s = json.find_first_of("0123456789", pos);
+        e = json.find_first_not_of("0123456789", s);
+        uint16_t st = static_cast<uint16_t>(std::stoi(json.substr(s, e - s)));
+        pos = json.find("\"sceneId\"", pos);
+        pos = json.find(':', pos);
+        s = json.find_first_of("0123456789", pos);
+        e = json.find_first_not_of("0123456789", s);
+        uint32_t sc = std::stoul(json.substr(s, e - s));
+        g_romance[q][st] = sc;
     }
 }
 
 void QuestWatchdog_Tick(float dt)
 {
+    if (g_voteActive)
+    {
+        g_voteTimer -= dt / 1000.f;
+        size_t total = Net_GetConnections().size();
+        size_t yes = 0;
+        for (auto& kv : g_voteCast)
+            if (kv.second)
+                ++yes;
+        size_t uncast = total > g_voteCast.size() ? total - g_voteCast.size() : 0;
+        bool majority = yes > total / 2 || (g_voteTimer <= 0.f && yes + uncast > total / 2);
+        if (majority)
+        {
+            uint16_t stage = g_phaseStages[g_votePhase][g_voteQuest];
+            for (auto& peer : g_phaseStages)
+            {
+                peer.second[g_voteQuest] = stage;
+                Connection* c = Net_FindConnection(peer.first);
+                if (c)
+                {
+                    QuestStageP2PPacket pkt{peer.first, g_voteQuest, stage, 0};
+                    Net_Send(c, EMsg::QuestStageP2P, &pkt, sizeof(pkt));
+                }
+            }
+            PhaseTrigger_Clear(g_votePhase);
+            g_voteActive = false;
+            g_voteCast.clear();
+        }
+
+        if (g_endVoteActive)
+        {
+            g_endVoteTimer -= dt / 1000.f;
+            size_t total = Net_GetConnections().size();
+            size_t yes = 0;
+            for (auto& kv : g_endVoteCast)
+                if (kv.second)
+                    ++yes;
+            size_t uncast = total > g_endVoteCast.size() ? total - g_endVoteCast.size() : 0;
+            bool majority = yes > total / 2 || (g_endVoteTimer <= 0.f && yes + uncast > total / 2);
+            if (majority)
+            {
+                Net_BroadcastCineStart(Fnv1a32("ending_roof"), 0u, 0u, false);
+                g_phaseStages.clear();
+                g_endVoteActive = false;
+                g_endVoteCast.clear();
+            }
+            else if (g_endVoteTimer <= 0.f)
+            {
+                g_endVoteActive = false;
+                g_endVoteCast.clear();
+            }
+        }
+        else if (g_voteTimer <= 0.f)
+        {
+            g_voteActive = false;
+            g_voteCast.clear();
+        }
+    }
+
     g_timer += dt;
     g_window += dt;
     if (g_window >= 300.f)
@@ -110,6 +257,7 @@ void QuestWatchdog_Tick(float dt)
                             QuestFullSyncPacket pkt{};
                             QuestWatchdog_BuildFullSync(peer.first, pkt);
                             Net_SendQuestFullSync(conn, pkt);
+                            PhaseTrigger_Clear(peer.first);
                         }
                     }
                 }

--- a/cp2077-coop/src/server/QuestWatchdog.hpp
+++ b/cp2077-coop/src/server/QuestWatchdog.hpp
@@ -3,6 +3,7 @@
 
 #include "../net/Packets.hpp"
 #include <cstdint>
+#include <vector>
 
 namespace CoopNet
 {
@@ -12,6 +13,9 @@ void QuestWatchdog_Tick(float dt);
 void QuestWatchdog_BuildFullSync(uint32_t phaseId, QuestFullSyncPacket& outPkt); // PX-2
 std::vector<uint32_t> QuestWatchdog_ListPhases();                                // PX-7
 void QuestWatchdog_LoadCritical();                                               // PX-6
+void QuestWatchdog_LoadRomance();                                                // RM-1
+void QuestWatchdog_HandleVote(uint32_t peerId, bool yes);                        // PX-6
+void QuestWatchdog_HandleEndingVote(uint32_t peerId, bool yes);                  // EG-1
 
 } // namespace CoopNet
 

--- a/cp2077-coop/src/server/ShardController.cpp
+++ b/cp2077-coop/src/server/ShardController.cpp
@@ -1,0 +1,49 @@
+#include "ShardController.hpp"
+#include "../net/Net.hpp"
+#include "../net/Packets.hpp"
+#include <cstdlib>
+
+namespace CoopNet
+{
+static bool g_active = false;
+static uint32_t g_phase = 0;
+static uint32_t g_seed = 0;
+static float g_progress = 0.f;
+static float g_send = 0.f;
+
+void ShardController_Start(uint32_t phaseId)
+{
+    g_active = true;
+    g_phase = phaseId;
+    g_seed = static_cast<uint32_t>(std::rand());
+    g_progress = 0.f;
+    g_send = 0.f;
+    Net_BroadcastTileGameStart(phaseId, g_seed);
+}
+
+void ShardController_HandleSelect(uint32_t peerId, uint8_t row, uint8_t col)
+{
+    if (!g_active)
+        return;
+    Net_BroadcastTileSelect(peerId, g_phase, row, col);
+}
+
+void ShardController_ServerTick(float dt)
+{
+    if (!g_active)
+        return;
+    g_progress += dt / 10000.f * 100.f; // 10s full
+    g_send += dt;
+    if (g_send >= 500.f)
+    {
+        g_send = 0.f;
+        uint8_t pct = static_cast<uint8_t>(g_progress);
+        if (pct > 100)
+            pct = 100;
+        Net_BroadcastShardProgress(g_phase, pct);
+        if (pct >= 100)
+            g_active = false;
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/ShardController.hpp
+++ b/cp2077-coop/src/server/ShardController.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+
+namespace CoopNet
+{
+void ShardController_Start(uint32_t phaseId);
+void ShardController_HandleSelect(uint32_t peerId, uint8_t row, uint8_t col);
+void ShardController_ServerTick(float dt);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/SkillController.cpp
+++ b/cp2077-coop/src/server/SkillController.cpp
@@ -1,0 +1,37 @@
+#include "SkillController.hpp"
+#include "../net/Net.hpp"
+#include "Connection.hpp"
+#include <iostream>
+#include <unordered_map>
+
+namespace CoopNet
+{
+static std::unordered_map<uint32_t, std::unordered_map<uint16_t, int32_t>> g_skillTable;
+
+void SkillController_HandleXP(Connection* conn, uint16_t skillId, int16_t delta)
+{
+    if (!conn)
+        return;
+    if (delta > 500)
+        delta = 500;
+    else if (delta < -500)
+        delta = -500;
+    int32_t& xp = g_skillTable[conn->peerId][skillId];
+    xp += delta;
+    Net_BroadcastSkillXP(conn->peerId, skillId, delta);
+    std::cout << "SkillXP peer=" << conn->peerId << " skill=" << skillId << " delta=" << delta << std::endl;
+}
+
+int32_t SkillController_GetXP(uint32_t peerId, uint16_t skillId)
+{
+    auto pit = g_skillTable.find(peerId);
+    if (pit != g_skillTable.end())
+    {
+        auto sit = pit->second.find(skillId);
+        if (sit != pit->second.end())
+            return sit->second;
+    }
+    return 0;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/SkillController.hpp
+++ b/cp2077-coop/src/server/SkillController.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+namespace CoopNet
+{
+class Connection;
+void SkillController_HandleXP(Connection* conn, uint16_t skillId, int16_t delta);
+int32_t SkillController_GetXP(uint32_t peerId, uint16_t skillId);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/TradeController.cpp
+++ b/cp2077-coop/src/server/TradeController.cpp
@@ -1,0 +1,111 @@
+#include "TradeController.hpp"
+#include "../net/Net.hpp"
+#include "InventoryController.hpp"
+#include "LedgerService.hpp"
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+namespace CoopNet
+{
+struct TradeState
+{
+    uint32_t a;
+    uint32_t b;
+    std::vector<ItemSnap> offerA;
+    std::vector<ItemSnap> offerB;
+    uint32_t eddiesA = 0;
+    uint32_t eddiesB = 0;
+    bool acceptA = false;
+    bool acceptB = false;
+};
+static TradeState g_trade;
+static bool g_active = false;
+
+void TradeController_Start(uint32_t fromId, uint32_t toId)
+{
+    g_trade = TradeState{};
+    g_trade.a = fromId;
+    g_trade.b = toId;
+    g_active = true;
+    TradeInitPacket pkt{fromId, toId};
+    Connection* a = Net_FindConnection(fromId);
+    Connection* b = Net_FindConnection(toId);
+    if (a)
+        Net_Send(a, EMsg::TradeInit, &pkt, sizeof(pkt));
+    if (b)
+        Net_Send(b, EMsg::TradeInit, &pkt, sizeof(pkt));
+}
+
+static bool ValidateItems(uint32_t peerId, const TradeOfferPacket& pkt)
+{
+    for (uint8_t i = 0; i < pkt.count && i < 8; ++i)
+    {
+        auto it = g_items.find(pkt.items[i].itemId);
+        if (it == g_items.end() || it->second.ownerId != peerId)
+            return false;
+    }
+    return true;
+}
+
+void TradeController_HandleOffer(Connection* conn, const TradeOfferPacket& pkt)
+{
+    if (!g_active || !conn)
+        return;
+    if (pkt.fromId != conn->peerId)
+        return;
+    if (!ValidateItems(conn->peerId, pkt))
+        return;
+    std::vector<ItemSnap>& offer = (pkt.fromId == g_trade.a) ? g_trade.offerA : g_trade.offerB;
+    offer.clear();
+    for (uint8_t i = 0; i < pkt.count && i < 8; ++i)
+        offer.push_back(pkt.items[i]);
+    if (pkt.fromId == g_trade.a)
+        g_trade.eddiesA = pkt.eddies;
+    else
+        g_trade.eddiesB = pkt.eddies;
+    g_trade.acceptA = g_trade.acceptB = false;
+    TradeOfferPacket fwd = pkt;
+    Connection* other = Net_FindConnection(pkt.fromId == g_trade.a ? g_trade.b : g_trade.a);
+    if (other)
+        Net_Send(other, EMsg::TradeOffer, &fwd, sizeof(fwd));
+}
+
+static void Finalize()
+{
+    for (auto& item : g_trade.offerA)
+    {
+        ItemSnap& snap = g_items[item.itemId];
+        snap.ownerId = g_trade.b;
+        ItemSnapPacket pkt{snap};
+        Net_Broadcast(EMsg::ItemSnap, &pkt, sizeof(pkt));
+    }
+    for (auto& item : g_trade.offerB)
+    {
+        ItemSnap& snap = g_items[item.itemId];
+        snap.ownerId = g_trade.a;
+        ItemSnapPacket pkt{snap};
+        Net_Broadcast(EMsg::ItemSnap, &pkt, sizeof(pkt));
+    }
+    uint64_t bal;
+    Ledger_Transfer(Net_FindConnection(g_trade.a), -static_cast<int64_t>(g_trade.eddiesA), 0, bal);
+    Ledger_Transfer(Net_FindConnection(g_trade.b), -static_cast<int64_t>(g_trade.eddiesB), 0, bal);
+    Ledger_Transfer(Net_FindConnection(g_trade.a), g_trade.eddiesB, 1, bal);
+    Ledger_Transfer(Net_FindConnection(g_trade.b), g_trade.eddiesA, 1, bal);
+    Net_BroadcastTradeFinalize(true);
+    g_active = false;
+}
+
+void TradeController_HandleAccept(Connection* conn, uint32_t peerId, bool accept)
+{
+    if (!g_active || !conn)
+        return;
+    if (peerId == g_trade.a)
+        g_trade.acceptA = accept;
+    else if (peerId == g_trade.b)
+        g_trade.acceptB = accept;
+    if (g_trade.acceptA && g_trade.acceptB)
+        Finalize();
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/TradeController.hpp
+++ b/cp2077-coop/src/server/TradeController.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "../net/Connection.hpp"
+#include "../net/Packets.hpp"
+
+namespace CoopNet
+{
+void TradeController_Start(uint32_t fromId, uint32_t toId);
+void TradeController_HandleOffer(Connection* conn, const TradeOfferPacket& pkt);
+void TradeController_HandleAccept(Connection* conn, uint32_t peerId, bool accept);
+} // namespace CoopNet

--- a/cp2077-coop/src/server/VehicleController.cpp
+++ b/cp2077-coop/src/server/VehicleController.cpp
@@ -1,6 +1,8 @@
 #include "VehicleController.hpp"
 #include "../core/GameClock.hpp"
 #include "../core/Hash.hpp"
+#include "../core/SaveFork.hpp"
+#include "../core/SessionState.hpp"
 #include "../net/Connection.hpp"
 #include "../net/Net.hpp"
 #include "../net/Packets.hpp"
@@ -19,24 +21,37 @@ struct VehicleState
     RED4ext::Vector3 prevVel{};
     bool destroyed = false;
     float despawn = 0.f;
+    float idle = 0.f;
+    uint32_t owner = 0;
+    uint32_t phaseId = 0;
     uint32_t seat[4] = {0, 0, 0, 0};
     float lastHit = 0.f;
+    float towTimer = 0.f;
 };
 
 static VehicleState g_vehicle;
 
-void VehicleController_Spawn(uint32_t archetype, uint32_t paint, const TransformSnap& t)
+void VehicleController_SpawnPhaseVehicle(uint32_t archetype, uint32_t paint, const TransformSnap& t, uint32_t phaseId)
 {
+    g_vehicle.phaseId = phaseId;
     g_vehicle.archetype = archetype;
     g_vehicle.paint = paint;
     g_vehicle.snap = t;
     g_vehicle.damage = 0;
     g_vehicle.destroyed = false;
     g_vehicle.despawn = 0.f;
+    g_vehicle.idle = 0.f;
+    g_vehicle.owner = 0;
+    g_vehicle.towTimer = 0.f;
     for (int i = 0; i < 4; ++i)
         g_vehicle.seat[i] = 0;
-    VehicleSpawnPacket pkt{g_vehicle.id, archetype, paint, t};
+    VehicleSpawnPacket pkt{g_vehicle.id, archetype, paint, phaseId, t};
     Net_Broadcast(EMsg::VehicleSpawn, &pkt, sizeof(pkt));
+}
+
+void VehicleController_Spawn(uint32_t archetype, uint32_t paint, const TransformSnap& t)
+{
+    VehicleController_SpawnPhaseVehicle(archetype, paint, t, 0u);
 }
 
 static float VecLen(const RED4ext::Vector3& v)
@@ -60,6 +75,13 @@ void VehicleController_ApplyDamage(uint16_t dmg, bool side)
         Net_Broadcast(EMsg::VehicleExplode, &pkt, sizeof(pkt));
         g_vehicle.destroyed = true;
         g_vehicle.despawn = 10.f;
+        g_vehicle.towTimer = 300.f;
+        CarParking cp{};
+        cp.vehTpl = g_vehicle.archetype;
+        cp.pos = g_vehicle.snap.pos;
+        cp.rot = g_vehicle.snap.rot;
+        cp.health = 0;
+        SaveCarParking(SessionState_GetId(), g_vehicle.owner, cp);
     }
 }
 
@@ -108,8 +130,35 @@ void VehicleController_HandleSummon(CoopNet::Connection* c, uint32_t vehId, cons
         g_vehicle.damage = 0;
         g_vehicle.destroyed = false;
     }
+    g_vehicle.owner = c->peerId;
+    g_vehicle.idle = 0.f;
     VehicleSummonPacket pkt{vehId, c->peerId, t};
     Net_Broadcast(EMsg::VehicleSummon, &pkt, sizeof(pkt));
+}
+
+static RED4ext::Vector3 FindSafePos(const RED4ext::Vector3& pos)
+{
+    // Engine nav query will snap to nearest road; placeholder returns input
+    return pos;
+}
+
+void VehicleController_HandleTowRequest(CoopNet::Connection* c, const RED4ext::Vector3& pos)
+{
+    if (!c || g_vehicle.owner != c->peerId)
+        return;
+    if (g_vehicle.destroyed)
+    {
+        g_vehicle.owner = 0;
+        g_vehicle.towTimer = 0.f;
+        if (Connection* target = Net_FindConnection(c->peerId))
+            Net_SendVehicleTowAck(target, c->peerId, true);
+        std::cout << "[Tow] Car returned" << std::endl;
+    }
+    else
+    {
+        g_vehicle.snap.pos = FindSafePos(pos);
+        Net_SendVehicleTowAck(c, c->peerId, true);
+    }
 }
 
 void VehicleController_RemovePeer(uint32_t peerId)
@@ -124,6 +173,17 @@ void VehicleController_ServerTick(float dt)
     if (g_vehicle.destroyed)
     {
         g_vehicle.despawn -= dt / 1000.f;
+        if (g_vehicle.towTimer > 0.f)
+        {
+            g_vehicle.towTimer -= dt / 1000.f;
+            if (g_vehicle.towTimer <= 0.f && g_vehicle.owner != 0)
+            {
+                if (Connection* c = Net_FindConnection(g_vehicle.owner))
+                    Net_SendVehicleTowAck(c, g_vehicle.owner, true);
+                std::cout << "[Tow] Car returned" << std::endl;
+                g_vehicle.owner = 0;
+            }
+        }
         return;
     }
     float vPrev = VecLen(g_vehicle.prevVel);
@@ -137,6 +197,25 @@ void VehicleController_ServerTick(float dt)
         g_vehicle.seat[0] = 0;
     }
     g_vehicle.prevVel = g_vehicle.snap.vel;
+    if (g_vehicle.seat[0] == 0 && vCur < 0.1f)
+    {
+        g_vehicle.idle += dt / 1000.f;
+        if (g_vehicle.idle >= 10.f)
+        {
+            CarParking cp{};
+            cp.vehTpl = g_vehicle.archetype;
+            cp.pos = g_vehicle.snap.pos;
+            cp.rot = g_vehicle.snap.rot;
+            cp.health = static_cast<uint16_t>(1000u - g_vehicle.damage);
+            SaveCarParking(SessionState_GetId(), g_vehicle.owner, cp);
+            Net_BroadcastTrafficDespawn(g_vehicle.id);
+            g_vehicle.idle = 0.f;
+        }
+    }
+    else
+    {
+        g_vehicle.idle = 0.f;
+    }
 }
 
 } // namespace CoopNet

--- a/cp2077-coop/src/server/VehicleController.hpp
+++ b/cp2077-coop/src/server/VehicleController.hpp
@@ -7,8 +7,10 @@ void VehicleController_ServerTick(float dt);
 void VehicleController_ApplyDamage(uint16_t dmg, bool side);
 void VehicleController_SetOccupant(uint32_t peerId);
 void VehicleController_Spawn(uint32_t archetype, uint32_t paint, const TransformSnap& t);
+void VehicleController_SpawnPhaseVehicle(uint32_t archetype, uint32_t paint, const TransformSnap& t, uint32_t phaseId);
 void VehicleController_HandleSeatRequest(CoopNet::Connection* c, uint32_t vehicleId, uint8_t seatIdx);
 void VehicleController_HandleHit(uint32_t vehicleId, uint16_t dmg, bool side);
 void VehicleController_RemovePeer(uint32_t peerId);
 void VehicleController_HandleSummon(CoopNet::Connection* c, uint32_t vehId, const TransformSnap& t);
+void VehicleController_HandleTowRequest(CoopNet::Connection* c, const RED4ext::Vector3& pos);
 } // namespace CoopNet


### PR DESCRIPTION
### Ticket
AI-1, AI-2, AI-3

### Summary
* Added `PanicEvent`, `AIHack`, and `BossPhase` packet types for upcoming AI features
* Broadcast helpers implemented in `Net.cpp` / `Net.hpp`
* Connection handler routes the new messages to script callbacks
* Introduced `PanicSync`, `AIHackSync`, and `BossPhaseSync` redscript stubs

### Testing Performed
- `pre-commit run --files cp2077-coop/src/net/Connection.cpp cp2077-coop/src/net/Net.cpp cp2077-coop/src/net/Net.hpp cp2077-coop/src/net/Packets.hpp cp2077-coop/src/runtime/PanicSync.reds cp2077-coop/src/runtime/AIHackSync.reds cp2077-coop/src/runtime/BossPhaseSync.reds`


------
https://chatgpt.com/codex/tasks/task_e_685dff36646883308841bf0a3db33347