### PR TITLE
Async server browser queries

### DIFF
--- a/cp2077-coop/src/core/HttpClient.cpp
+++ b/cp2077-coop/src/core/HttpClient.cpp
@@ -1,7 +1,10 @@
 #include "HttpClient.hpp"
 #include "../../third_party/httplib.h"
+#include "ThreadSafeQueue.hpp"
 #include <string>
 #include <cstdlib>
+#include <thread>
+#include <atomic>
 
 namespace CoopNet {
 
@@ -45,6 +48,28 @@ HttpResponse Http_Get(const std::string& url)
     return {static_cast<uint16_t>(res.status), res.body};
 }
 
+HttpResponse Http_Get(const std::string& url, int timeoutMs)
+{
+    std::string host, path;
+    int port;
+    bool https = ParseUrl(url, host, port, path);
+    httplib::Result res{};
+    if (https) {
+        httplib::SSLClient cli(host, port);
+        cli.set_connection_timeout(timeoutMs / 1000, (timeoutMs % 1000) * 1000);
+        cli.set_read_timeout(timeoutMs / 1000, (timeoutMs % 1000) * 1000);
+        res = cli.Get(path.c_str());
+    } else {
+        httplib::Client cli(host, port);
+        cli.set_connection_timeout(timeoutMs / 1000, (timeoutMs % 1000) * 1000);
+        cli.set_read_timeout(timeoutMs / 1000, (timeoutMs % 1000) * 1000);
+        res = cli.Get(path.c_str());
+    }
+    if (res.status == 0)
+        return {0, {}};
+    return {static_cast<uint16_t>(res.status), res.body};
+}
+
 HttpResponse Http_Post(const std::string& url, const std::string& body, const std::string& contentType)
 {
     std::string host, path;
@@ -61,6 +86,29 @@ HttpResponse Http_Post(const std::string& url, const std::string& body, const st
     if (res.status == 0)
         return {0, {}};
     return {static_cast<uint16_t>(res.status), res.body};
+}
+
+static std::atomic<uint32_t> g_nextToken{1};
+static ThreadSafeQueue<HttpAsyncResult> g_asyncQueue;
+
+uint32_t Http_GetAsync(const std::string& url, int timeoutMs, int retries)
+{
+    uint32_t id = g_nextToken.fetch_add(1, std::memory_order_relaxed);
+    std::thread([url, id, timeoutMs, retries]() {
+        HttpResponse r{};
+        for (int i = 0; i <= retries; ++i) {
+            r = Http_Get(url, timeoutMs);
+            if (r.status != 0)
+                break;
+        }
+        g_asyncQueue.Push({id, r});
+    }).detach();
+    return id;
+}
+
+bool Http_PollAsync(HttpAsyncResult& out)
+{
+    return g_asyncQueue.Pop(out);
 }
 
 } // namespace CoopNet

--- a/cp2077-coop/src/core/HttpClient.hpp
+++ b/cp2077-coop/src/core/HttpClient.hpp
@@ -5,6 +5,14 @@ struct HttpResponse {
     uint16_t status;
     std::string body;
 };
+struct HttpAsyncResult {
+    uint32_t token;
+    HttpResponse resp;
+};
+
 HttpResponse Http_Get(const std::string& url);
+HttpResponse Http_Get(const std::string& url, int timeoutMs);
 HttpResponse Http_Post(const std::string& url, const std::string& body, const std::string& contentType);
+uint32_t Http_GetAsync(const std::string& url, int timeoutMs, int retries);
+bool Http_PollAsync(HttpAsyncResult& out);
 }

--- a/cp2077-coop/src/gui/HttpRequest.reds
+++ b/cp2077-coop/src/gui/HttpRequest.reds
@@ -3,6 +3,12 @@ public struct HttpResponse {
     public var body: String;
 }
 
+public struct HttpAsyncResult {
+    public var token: Uint32;
+    public var status: Uint16;
+    public var body: String;
+}
+
 public class HttpRequest {
     private var url: String;
     private var status: Uint16;
@@ -10,6 +16,8 @@ public class HttpRequest {
 
     private static native func HttpRequest_HttpGet(url: String) -> HttpResponse
     private static native func HttpRequest_HttpPost(url: String, payload: String, mime: String) -> HttpResponse
+    private static native func HttpRequest_HttpGetAsync(url: String) -> Uint32
+    private static native func HttpRequest_PollAsync() -> HttpAsyncResult
 
     public func SetUrl(u: String) -> Void {
         url = u;
@@ -20,6 +28,12 @@ public class HttpRequest {
         status = res.status;
         text = res.body;
         url = "";
+    }
+
+    public func SendAsync() -> Uint32 {
+        let id = HttpRequest_HttpGetAsync(url);
+        url = "";
+        return id;
     }
 
     public func SendPost(payload: String, mime: String) -> Void {
@@ -41,5 +55,9 @@ public class HttpRequest {
         url = "";
         status = 0u;
         text = "";
+    }
+
+    public static func PollAsync() -> HttpAsyncResult {
+        return HttpRequest_PollAsync();
     }
 }


### PR DESCRIPTION
## Summary
- add async HTTP helper with timeout and queue
- expose async functions to Redscript
- refresh server browser asynchronously

## Testing
- `pre-commit` *(fails: network credentials)*


------
https://chatgpt.com/codex/tasks/task_e_686f22a0a7608330834ff3db622f4337