### PR TITLE
Add voice codec configuration

### DIFF
--- a/cp2077-coop/src/core/CoopExports.cpp
+++ b/cp2077-coop/src/core/CoopExports.cpp
@@ -63,10 +63,14 @@ static void NetPollFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*
 static void VoiceStartFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, void*)
 {
     RED4ext::CString dev;
+    uint32_t sr = 48000;
+    uint32_t br = 24000;
     RED4ext::GetParameter(aFrame, &dev);
+    RED4ext::GetParameter(aFrame, &sr);
+    RED4ext::GetParameter(aFrame, &br);
     aFrame->code++;
     if (aOut)
-        *aOut = CoopVoice::StartCapture(dev.c_str());
+        *aOut = CoopVoice::StartCapture(dev.c_str(), sr, br);
 }
 
 static void VoiceEncodeFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, int32_t* aOut, void*)
@@ -149,6 +153,8 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes()
     auto vs = RED4ext::CGlobalFunction::Create("CoopVoice_StartCapture", "CoopVoice_StartCapture", &VoiceStartFn);
     vs->flags = flags;
     vs->AddParam("String", "device");
+    vs->AddParam("Uint32", "sampleRate");
+    vs->AddParam("Uint32", "bitrate");
     vs->SetReturnType("Bool");
     rtti->RegisterFunction(vs);
 

--- a/cp2077-coop/src/gui/ChatOverlay.reds
+++ b/cp2077-coop/src/gui/ChatOverlay.reds
@@ -56,13 +56,13 @@ public class ChatOverlay extends inkHUDLayer {
         let input = GameInstance.GetInputSystem(GetGame());
         if input.IsPressed(CoopSettings.pushToTalk) {
             if !talking {
-                CoopVoice.StartCapture("default");
+                CoopVoice.StartCapture("default", CoopSettings.voiceSampleRate, CoopSettings.voiceBitrate);
                 talking = true;
                 LogChannel(n"DEBUG", "PTT start");
                 MicIcon.Show();
             };
             let pcm: array<Int16>;
-            pcm.Resize(960);
+            pcm.Resize(Cast<Int32>(CoopSettings.voiceSampleRate / 50u));
             let buf: array<Uint8>;
             buf.Resize(256);
             let written = CoopVoice.EncodeFrame(pcm[0], buf[0]);

--- a/cp2077-coop/src/gui/CoopSettings.reds
+++ b/cp2077-coop/src/gui/CoopSettings.reds
@@ -2,6 +2,8 @@
 public var tickRate: Uint16 = 30;
 public var interpMs: Uint16 = 100;
 public var pushToTalk: EKey = EKey.T;
+public var voiceSampleRate: Uint32 = 48000u;
+public var voiceBitrate: Uint32 = 24000u;
 public var friendlyFire: Bool = false;
 public var sharedLoot: Bool = true;
 public var difficultyScaling: Bool = false;

--- a/cp2077-coop/src/runtime/VoiceAPI.reds
+++ b/cp2077-coop/src/runtime/VoiceAPI.reds
@@ -1,5 +1,5 @@
 public class CoopVoice {
-    public static native func StartCapture(device: String) -> Bool
+    public static native func StartCapture(device: String, sampleRate: Uint32, bitrate: Uint32) -> Bool
     public static native func EncodeFrame(pcm: script_ref<Int16>, buf: script_ref<Uint8>) -> Int32
     public static native func StopCapture() -> Void
 }

--- a/cp2077-coop/src/voice/VoiceEncoder.cpp
+++ b/cp2077-coop/src/voice/VoiceEncoder.cpp
@@ -10,31 +10,50 @@ namespace CoopVoice
 static bool g_capturing = false;
 static OpusEncoder* g_encoder = nullptr;
 static ALCdevice* g_capDev = nullptr;
+static uint32_t g_sampleRate = 48000;
+static uint32_t g_bitrate = 24000;
+static int g_frameSamples = 960;
 
-bool StartCapture(const char* deviceName)
+bool StartCapture(const char* deviceName, uint32_t sampleRate, uint32_t bitrate)
 {
     if (g_capturing)
         return true;
 
-    std::cout << "[Voice] StartCapture dev=" << (deviceName ? deviceName : "default") << std::endl;
+    g_sampleRate = sampleRate;
+    g_bitrate = bitrate;
+    g_frameSamples = static_cast<int>(g_sampleRate / 50);
+
+    std::cout << "[Voice] StartCapture dev=" << (deviceName ? deviceName : "default") << " sr=" << g_sampleRate << " br=" << g_bitrate << std::endl;
 
     const ALCchar* dev = (deviceName && *deviceName) ? deviceName : nullptr;
-    g_capDev = alcCaptureOpenDevice(dev, 48000, AL_FORMAT_MONO16, 960 * 10);
+    g_capDev = alcCaptureOpenDevice(dev, g_sampleRate, AL_FORMAT_MONO16, g_frameSamples * 10);
     if (!g_capDev)
     {
         std::cerr << "Failed to open capture device" << std::endl;
-        return false;
+        if (g_sampleRate != 48000)
+        {
+            g_sampleRate = 48000;
+            g_frameSamples = 960;
+            g_capDev = alcCaptureOpenDevice(dev, g_sampleRate, AL_FORMAT_MONO16, g_frameSamples * 10);
+        }
+        if (!g_capDev)
+            return false;
     }
     alcCaptureStart(g_capDev);
 
     int err = 0;
-    g_encoder = opus_encoder_create(48000, 1, OPUS_APPLICATION_VOIP, &err);
+    g_encoder = opus_encoder_create(g_sampleRate, 1, OPUS_APPLICATION_VOIP, &err);
     if (err != OPUS_OK)
     {
         std::cerr << "Failed to init Opus encoder" << std::endl;
         alcCaptureCloseDevice(g_capDev);
         g_capDev = nullptr;
         return false;
+    }
+    if (opus_encoder_ctl(g_encoder, OPUS_SET_BITRATE(g_bitrate)) != OPUS_OK)
+    {
+        opus_encoder_ctl(g_encoder, OPUS_SET_BITRATE(24000));
+        g_bitrate = 24000;
     }
 
     g_capturing = true;
@@ -48,11 +67,11 @@ int EncodeFrame(int16_t* pcm, uint8_t* outBuf)
 
     ALCint avail = 0;
     alcGetIntegerv(g_capDev, ALC_CAPTURE_SAMPLES, 1, &avail);
-    if (avail < 960)
+    if (avail < g_frameSamples)
         return 0;
 
-    alcCaptureSamples(g_capDev, pcm, 960);
-    int bytes = opus_encode(g_encoder, pcm, 960, outBuf, 256);
+    alcCaptureSamples(g_capDev, pcm, g_frameSamples);
+    int bytes = opus_encode(g_encoder, pcm, g_frameSamples, outBuf, 256);
     if (bytes < 0)
         return 0;
     return bytes;

--- a/cp2077-coop/src/voice/VoiceEncoder.hpp
+++ b/cp2077-coop/src/voice/VoiceEncoder.hpp
@@ -3,7 +3,7 @@
 
 namespace CoopVoice
 {
-bool StartCapture(const char* deviceName);
+bool StartCapture(const char* deviceName, uint32_t sampleRate, uint32_t bitrate);
 int EncodeFrame(int16_t* pcm, uint8_t* outBuf);
 void StopCapture();
 } // namespace CoopVoice


### PR DESCRIPTION
### Summary
* Added `voiceSampleRate` and `voiceBitrate` fields to `CoopSettings`.
* Updated `VoiceEncoder` to accept sample rate/bitrate parameters and validate them.
* Extended scripting interface and exports to pass new parameters.
* Chat overlay now allocates PCM buffers based on configured sample rate.

### Testing Performed
- `pytest -q` (no tests found)



------
https://chatgpt.com/codex/tasks/task_e_686f22ad0a188330bd128856b486a079