### PR TITLE
Handle unknown quest hashes in QuestSync

### DIFF
--- a/cp2077-coop/src/runtime/QuestSync.reds
+++ b/cp2077-coop/src/runtime/QuestSync.reds
@@ -44,6 +44,10 @@ public class QuestSync {
     }
 
     public static func ApplyQuestStageByHash(hash: Uint32, stage: Uint16) -> Void {
+        if !nameMap.Contains(hash) {
+            LogChannel(n"WARNING", "[QuestSync] Unknown quest hash " + IntToString(Cast<Int32>(hash)));
+            return;
+        };
         let name: CName = nameMap.Get(hash) as CName;
         ApplyQuestStage(name, stage);
     }

--- a/cp2077-coop/tests/test_quest_sync.py
+++ b/cp2077-coop/tests/test_quest_sync.py
@@ -1,0 +1,19 @@
+# Unit tests for QuestSync helper logic
+
+from typing import Dict, List
+
+# Minimal Python mirror of ApplyQuestStageByHash
+
+def apply_stage_by_hash(name_map: Dict[int, str], stage_map: Dict[int, int], hash_val: int, stage: int, log: List[str]) -> None:
+    if hash_val not in name_map:
+        log.append(f"warn unknown quest hash {hash_val}")
+        return
+    stage_map[hash_val] = stage
+
+def test_invalid_quest_hash():
+    logs: List[str] = []
+    names: Dict[int, str] = {}
+    stages: Dict[int, int] = {}
+    apply_stage_by_hash(names, stages, 0xDEADBEEF, 3, logs)
+    assert logs and "unknown quest hash" in logs[0]
+    assert 0xDEADBEEF not in stages


### PR DESCRIPTION
### Summary
* Prevent invalid cast by checking `nameMap` in `ApplyQuestStageByHash`.
* Log a warning and skip updates for unknown hashes.
* Added python unit test for invalid quest hash handling.

### Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f22ce28fc8330a185a520b5381596