### PR TITLE
Finalize trade packet flow

### DIFF
--- a/cp2077-coop/src/runtime/TradeWindow.reds
+++ b/cp2077-coop/src/runtime/TradeWindow.reds
@@ -1,20 +1,30 @@
 public class TradeWindow extends inkHUDLayer {
     private static let s_instance: ref<TradeWindow>;
+    private static let s_partner: Uint32;
     public static exec func Trade(peer: Int32) -> Void {
         CoopNotice.Show("Opening trade");
         CoopNet.Net_SendTradeInit(Cast<Uint32>(peer));
+    }
+    public static func SubmitOffer(items: script_ref<array<ItemSnap>>, count: Uint8, eddies: Uint32) -> Void {
+        CoopNet.Net_SendTradeOffer(items, count, eddies);
+    }
+    public static func SubmitAccept(ok: Bool) -> Void {
+        CoopNet.Net_SendTradeAccept(ok);
     }
     public static func OnInit(from: Uint32) -> Void {
         if IsDefined(s_instance) { return; };
         let hud = GameInstance.GetHUDManager(GetGame());
         s_instance = new TradeWindow();
+        s_partner = from;
         hud.AddLayer(s_instance);
     }
     public static func OnOffer(from: Uint32, items: script_ref<array<ItemSnap>>, count: Uint8, eddies: Uint32) -> Void {
         LogChannel(n"trade", "offer from=" + IntToString(Cast<Int32>(from)));
+        // FIXME(next ticket): populate UI with received items and eddies
     }
     public static func OnAccept(peer: Uint32, ok: Bool) -> Void {
-        LogChannel(n"trade", "accept from=" + IntToString(Cast<Int32>(peer)));
+        let who: String = peer == Net_GetLocalPeerId() ? "You" : "Partner";
+        CoopNotice.Show(who + (ok ? " accepted" : " declined"));
     }
     public static func OnFinalize(ok: Bool) -> Void {
         CoopNotice.Show("Trade " + (ok ? "complete" : "cancelled"));


### PR DESCRIPTION
### Ticket
TRD-1 · Finalize trade window packets

### Summary
* Added `SubmitOffer` and `SubmitAccept` helpers plus partner tracking.
* Server validates stored item ownership and broadcasts accept status.

### Files Touched
- `cp2077-coop/src/runtime/TradeWindow.reds` (+11 / -1)
- `cp2077-coop/src/server/TradeController.cpp` (+30)

### Logic Walk-Through
1. `SubmitOffer()` and `SubmitAccept()` wrap network send calls.
2. `OnAccept()` shows a `CoopNotice` on any acceptance or decline.
3. `Finalize()` aborts if items aren't owned by the sender.
4. `TradeController_HandleAccept()` forwards accept/decline packets to each party.

### Unfinished / TODO
- Incoming offer UI population left as `FIXME(next ticket)`.

### Testing Performed
- `pre-commit` failed: GitHub fetch blocked.

### Links / Context
Implements remaining TRD-1 trade flow.

------
https://chatgpt.com/codex/tasks/task_e_686f22f7b79c8330afddf2e122d54f74