### PR TITLE
Implement latency-driven tick scaling

### DIFF
--- a/cp2077-coop/src/gui/CoopSettings.reds
+++ b/cp2077-coop/src/gui/CoopSettings.reds
@@ -1,5 +1,7 @@
 // User-configurable coop settings.
 public var tickRate: Uint16 = 30;
+public var minTickRate: Uint16 = 20;
+public var maxTickRate: Uint16 = 50;
 public var interpMs: Uint16 = 100;
 public var pushToTalk: EKey = EKey.T;
 public var voiceSampleRate: Uint32 = 48000u;
@@ -20,7 +22,11 @@ public func Apply() -> Void {
 }
 
 public func Save(path: String) -> Void {
-    let json = "{\"friendlyFire\":" + BoolToString(friendlyFire) + ",\"sharedLoot\":" + BoolToString(sharedLoot) + ",\"difficultyScaling\":" + BoolToString(difficultyScaling) + "}";
+    let json = "{\"friendlyFire\":" + BoolToString(friendlyFire) +
+                ",\"sharedLoot\":" + BoolToString(sharedLoot) +
+                ",\"difficultyScaling\":" + BoolToString(difficultyScaling) +
+                ",\"minTickRate\":" + IntToString(Cast<Int32>(minTickRate)) +
+                ",\"maxTickRate\":" + IntToString(Cast<Int32>(maxTickRate)) + "}";
     SaveSettings(json);
     LogChannel(n"DEBUG", "Saved settings");
 }

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -1954,6 +1954,21 @@ bool Connection::PopPacket(RawPacket& out)
     return m_incoming.Pop(out);
 }
 
+float Connection::GetAverageRtt() const
+{
+    float sum = 0.f;
+    int count = 0;
+    for (float v : rttHist)
+    {
+        if (v > 0.f)
+        {
+            sum += v;
+            ++count;
+        }
+    }
+    return count ? sum / count : rttMs;
+}
+
 void Connection::Transition(ConnectionState next)
 {
     if (state != next)

--- a/cp2077-coop/src/net/Connection.hpp
+++ b/cp2077-coop/src/net/Connection.hpp
@@ -47,6 +47,8 @@ public:
         return state;
     }
 
+    float GetAverageRtt() const;
+
 private:
     void Transition(ConnectionState next);
 

--- a/cp2077-coop/src/server/DedicatedMain.cpp
+++ b/cp2077-coop/src/server/DedicatedMain.cpp
@@ -94,6 +94,7 @@ int main(int argc, char** argv)
     float goodTime = 0.f;
     float hbTimer = 0.f;
     float memTimer = 0.f;
+    float latencyTimer = 0.f;
     float scaleTimer = 0.f;
     float scaleAccum = 0.f;
     int scaleFrames = 0;
@@ -171,6 +172,7 @@ int main(int argc, char** argv)
         memTimer += tickMs / 1000.f;
         CoopNet::TextureGuard_Tick(tickMs / 1000.f);
         CoopNet::SectorLODController_Tick(tickMs / 1000.f);
+        latencyTimer += tickMs / 1000.f;
         for (auto* c : Net_GetConnections())
         {
             uint64_t now = CoopNet::GameClock::GetTimeMs();
@@ -189,6 +191,33 @@ int main(int argc, char** argv)
                     Net_SendLowBWMode(c, false);
                 }
             }
+        }
+        if (latencyTimer >= 10.f)
+        {
+            float sum = 0.f;
+            int cnt = 0;
+            for (auto* c : Net_GetConnections())
+            {
+                sum += c->GetAverageRtt();
+                ++cnt;
+            }
+            if (cnt > 0)
+            {
+                float avgRtt = sum / cnt;
+                if (avgRtt > 200.f && tickMs < 40.f)
+                {
+                    tickMs = 40.f;
+                    CoopNet::GameClock::SetTickMs(tickMs);
+                    Net_BroadcastTickRateChange(static_cast<uint16_t>(tickMs));
+                }
+                else if (avgRtt < 120.f && tickMs > 25.f)
+                {
+                    tickMs = 25.f;
+                    CoopNet::GameClock::SetTickMs(tickMs);
+                    Net_BroadcastTickRateChange(static_cast<uint16_t>(tickMs));
+                }
+            }
+            latencyTimer = 0.f;
         }
         // Heartbeat every six minutes so master server can prune stale hosts
         if (hbTimer >= 360.f)


### PR DESCRIPTION
## Summary
- compute average RTT for each connection
- scale server tick interval if RTT exceeds bounds
- broadcast updated TickRateChangePacket
- expose `minTickRate` and `maxTickRate` in settings

## Testing
- `pre-commit` *(fails: requires network auth)*

------
https://chatgpt.com/codex/tasks/task_e_686f2670200c8330a1f5c296f9eeb698