### PR TITLE
Implement NAT handshake with master server

### DIFF
--- a/cp2077-coop/src/net/NatClient.hpp
+++ b/cp2077-coop/src/net/NatClient.hpp
@@ -13,6 +13,7 @@ class Connection;
 void Nat_PerformHandshake(Connection* conn);
 
 uint64_t Nat_GetRelayBytes();
+const std::string& Nat_GetLocalCandidate();
 void Nat_AddRemoteCandidate(const char* cand);
 
 void Nat_SetTurnCreds(const std::string& host, int port,


### PR DESCRIPTION
## Summary
- expose local ICE candidate via `NatClient`
- send and receive candidate strings during heartbeat with master server
- log whether a direct hole punch or relay was used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f268589dc8330948db14fe731e8cf