### PR TITLE
Add loading spinner to ServerBrowser

### DIFF
--- a/cp2077-coop/src/gui/ServerBrowser.reds
+++ b/cp2077-coop/src/gui/ServerBrowser.reds
@@ -5,6 +5,7 @@ public class ServerBrowser extends inkHUDLayer {
     private static let scrollCtrl: wref<inkScrollController>;
     private static let joinBtn: wref<inkButton>;
     private static let hostBtn: wref<inkButton>;
+    private static let loadingSpinner: wref<inkText>;
     private static var masterToken: Uint32;
     private static let pending: ref<inkHashMap> = new inkHashMap();
     private static var pendingCount: Uint32;
@@ -47,6 +48,11 @@ public class ServerBrowser extends inkHUDLayer {
         hostBtn.SetText("HOST");
         hostBtn.RegisterToCallback(n"OnRelease", layer, n"OnHostClick");
         root.AddChild(hostBtn);
+
+        loadingSpinner = new inkText();
+        loadingSpinner.SetText("Loading...");
+        loadingSpinner.SetVisible(false);
+        root.AddChild(loadingSpinner);
         RefreshLive();
     }
 
@@ -88,6 +94,9 @@ public class ServerBrowser extends inkHUDLayer {
         ArrayClear(results);
         pendingCount = 0u;
         lastQuery = "";
+        if IsDefined(loadingSpinner) {
+            loadingSpinner.SetVisible(true);
+        };
         QueryMaster();
     }
 
@@ -218,6 +227,12 @@ public class ServerBrowser extends inkHUDLayer {
                 idx += 1;
             };
         };
+        pending.Clear();
+        pendingCount = 0u;
+        masterToken = 0u;
+        if IsDefined(loadingSpinner) {
+            loadingSpinner.SetVisible(false);
+        };
     }
 
     public func OnUpdate(dt: Float) -> Void {
@@ -264,6 +279,9 @@ public class ServerBrowser extends inkHUDLayer {
                     }
                 }
             }
+        }
+        if pendingCount == 0u && IsDefined(loadingSpinner) && loadingSpinner.IsVisible() {
+            loadingSpinner.SetVisible(false);
         }
     }
 }


### PR DESCRIPTION
### Ticket
P3-2 · Server-browser panel

### Summary
* Added `loadingSpinner` widget and display logic during server queries.
* Cancel outstanding async requests when the browser closes.

### Files Touched
- `cp2077-coop/src/gui/ServerBrowser.reds` (+18)

### Logic Walk-Through
1. `Show()` now creates a hidden `loadingSpinner` text widget.
2. `RefreshLive()` displays the spinner and starts the async master query.
3. `OnUpdate()` hides the spinner after all async responses arrive.
4. `OnDetach()` clears pending tokens and hides the spinner.

### Unfinished / TODO
- None

### Testing Performed
- `python3 scripts/find_patterns.py` failed due to missing `ida_bytes` module.

### Links / Context
Improves user feedback for asynchronous server discovery.

------
https://chatgpt.com/codex/tasks/task_e_686f268ce680833099226dd31b7beeb6