### PR TITLE
Handle disconnect cleanup

### DIFF
--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -10,6 +10,7 @@
 #include "../server/StatusController.hpp"
 #include "../server/TrafficController.hpp"
 #include "../voice/VoiceDecoder.hpp"
+#include "../voice/VoiceEncoder.hpp"
 #include "../plugin/PluginManager.hpp"
 #include "../third_party/zstd/zstd.h"
 #include <openssl/sha.h>
@@ -549,9 +550,23 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
     case EMsg::Disconnect:
         Killfeed_Broadcast("0 disconnected");
         CoopNet::VehicleController_RemovePeer(peerId);
+        CoopVoice::StopCapture();
+        CoopVoice::Reset();
+        voiceMuted = false;
+        voiceMuteEndMs = 0;
+        muteUntilMs = 0;
+        RED4ext::ExecuteFunction("MicIcon", "SetMuted", nullptr, false);
+        RED4ext::ExecuteFunction("ClientPluginProxy", "ClearPending", nullptr);
         Transition(ConnectionState::Disconnected);
         CrowdCfgSync_OnRestore();
-        CoopNet::SaveSessionState(CoopNet::SessionState_GetId());
+        ChatOverlay_Push("Disconnected from server");
+        {
+            RED4ext::CString msg("Disconnected from server");
+            RED4ext::ExecuteFunction("CoopNotice", "Show", nullptr, &msg);
+        }
+        uint32_t sid = CoopNet::SessionState_GetId();
+        if (sid != 0)
+            CoopNet::SaveSessionState(sid);
         break;
     case EMsg::AvatarSpawn:
         if (size >= sizeof(AvatarSpawnPacket))

--- a/cp2077-coop/src/runtime/ClientPluginProxy.reds
+++ b/cp2077-coop/src/runtime/ClientPluginProxy.reds
@@ -13,6 +13,10 @@ public class ClientPluginProxy {
         register_rpc(CoopNet.Fnv1a32("popup"), _popup);
     }
 
+    public static func ClearPending() -> Void {
+        callbacks.Clear();
+    }
+
     public static func OnRpc(pkt: ref<PluginRPCPacket>) -> Void {
         let fn = callbacks.Get(pkt.fnHash) as func(String);
         if IsDefined(fn) {
@@ -30,4 +34,8 @@ public static func ClientPluginProxy_OnRpc(pkt: ref<PluginRPCPacket>) -> Void {
 
 public static func ClientPluginProxy_Init() -> Void {
     ClientPluginProxy.Init();
+}
+
+public static func ClientPluginProxy_ClearPending() -> Void {
+    ClientPluginProxy.ClearPending();
 }

--- a/cp2077-coop/src/voice/VoiceDecoder.cpp
+++ b/cp2077-coop/src/voice/VoiceDecoder.cpp
@@ -142,4 +142,36 @@ uint16_t ConsumeDropPct()
     g_dropped = 0;
     return pct;
 }
+
+void Reset()
+{
+    g_buffer.clear();
+    g_lastSeq = 0;
+    g_recv = 0;
+    g_dropped = 0;
+    if (g_decoder)
+    {
+        opus_decoder_destroy(g_decoder);
+        g_decoder = nullptr;
+    }
+    if (g_source)
+    {
+        alSourceStop(g_source);
+        alDeleteSources(1, &g_source);
+        g_source = 0;
+    }
+    alDeleteBuffers(4, g_buffers);
+    if (g_ctx)
+    {
+        alcMakeContextCurrent(nullptr);
+        alcDestroyContext(g_ctx);
+        g_ctx = nullptr;
+    }
+    if (g_dev)
+    {
+        alcCloseDevice(g_dev);
+        g_dev = nullptr;
+    }
+    g_bufIndex = 0;
+}
 } // namespace CoopVoice

--- a/cp2077-coop/src/voice/VoiceDecoder.hpp
+++ b/cp2077-coop/src/voice/VoiceDecoder.hpp
@@ -6,4 +6,5 @@ namespace CoopVoice
 void PushPacket(uint16_t seq, const uint8_t* data, uint16_t size);
 int DecodeFrame(int16_t* pcmOut);
 uint16_t ConsumeDropPct();
+void Reset();
 } // namespace CoopVoice


### PR DESCRIPTION
## Summary
- reset voice state on disconnect
- clear plugin RPC callbacks
- push disconnect notice and chat
- save session state only when valid

## Testing
- `pre-commit` *(fails: GitHub auth required)*

------
https://chatgpt.com/codex/tasks/task_e_686f269922a0833081e7f3d739789e81