### PR TITLE
Implement dynamic event broadcast toggle

### DIFF
--- a/cp2077-coop/src/gui/CoopSettings.reds
+++ b/cp2077-coop/src/gui/CoopSettings.reds
@@ -9,6 +9,7 @@ public var voiceBitrate: Uint32 = 24000u;
 public var friendlyFire: Bool = false;
 public var sharedLoot: Bool = true;
 public var difficultyScaling: Bool = false;
+public var dynamicEvents: Bool = true;
 public let kDefaultSettingsPath: String = "coop.ini";
 private native func SaveSettings(json: String) -> Void
 
@@ -25,6 +26,7 @@ public func Save(path: String) -> Void {
     let json = "{\"friendlyFire\":" + BoolToString(friendlyFire) +
                 ",\"sharedLoot\":" + BoolToString(sharedLoot) +
                 ",\"difficultyScaling\":" + BoolToString(difficultyScaling) +
+                ",\"dynamicEvents\":" + BoolToString(dynamicEvents) +
                 ",\"minTickRate\":" + IntToString(Cast<Int32>(minTickRate)) +
                 ",\"maxTickRate\":" + IntToString(Cast<Int32>(maxTickRate)) + "}";
     SaveSettings(json);

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -420,6 +420,11 @@ static void PanicSync_OnEvent(const CoopNet::PanicEventPacket& pkt)
     RED4ext::ExecuteFunction("PanicSync", "OnEvent", nullptr, &pkt);
 }
 
+static void DynamicEventSync_OnEvent(const CoopNet::DynamicEventPacket& pkt)
+{
+    RED4ext::ExecuteFunction("DynamicEventSync", "OnEvent", nullptr, &pkt);
+}
+
 static void AIHackSync_OnHack(uint32_t target, uint8_t effectId)
 {
     RED4ext::ExecuteFunction("AIHackSync", "OnHack", nullptr, target, effectId);
@@ -729,6 +734,13 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         {
             const PanicEventPacket* pkt = reinterpret_cast<const PanicEventPacket*>(payload);
             PanicSync_OnEvent(*pkt);
+        }
+        break;
+    case EMsg::DynamicEvent:
+        if (size >= sizeof(DynamicEventPacket))
+        {
+            const DynamicEventPacket* pkt = reinterpret_cast<const DynamicEventPacket*>(payload);
+            DynamicEventSync_OnEvent(*pkt);
         }
         break;
     case EMsg::BossPhase:

--- a/cp2077-coop/src/net/Net.cpp
+++ b/cp2077-coop/src/net/Net.cpp
@@ -689,6 +689,12 @@ void Net_BroadcastGlobalEvent(uint32_t eventId, uint8_t phase, bool start, uint3
     Net_Broadcast(EMsg::GlobalEvent, &pkt, sizeof(pkt));
 }
 
+void Net_BroadcastDynamicEvent(uint8_t eventType, uint32_t seed)
+{
+    DynamicEventPacket pkt{eventType, {0,0,0}, seed};
+    Net_Broadcast(EMsg::DynamicEvent, &pkt, sizeof(pkt));
+}
+
 void Net_BroadcastCrowdSeed(uint64_t sectorHash, uint32_t seed)
 {
     CrowdSeedPacket pkt{sectorHash, seed};

--- a/cp2077-coop/src/net/Net.hpp
+++ b/cp2077-coop/src/net/Net.hpp
@@ -86,6 +86,7 @@ void Net_SendGlobalEvent(CoopNet::Connection* conn, uint32_t eventId, uint8_t ph
 void Net_SendNpcReputation(CoopNet::Connection* conn, uint32_t npcId, int16_t value);
 void Net_BroadcastNpcReputation(uint32_t npcId, int16_t value);
 void Net_BroadcastGlobalEvent(uint32_t eventId, uint8_t phase, bool start, uint32_t seed);
+void Net_BroadcastDynamicEvent(uint8_t eventType, uint32_t seed); // DE-1
 void Net_BroadcastCrowdSeed(uint64_t sectorHash, uint32_t seed);
 void Net_BroadcastVendorStock(const VendorStockPacket& pkt);
 void Net_BroadcastVendorStockUpdate(const VendorStockUpdatePacket& pkt);

--- a/cp2077-coop/src/net/Packets.hpp
+++ b/cp2077-coop/src/net/Packets.hpp
@@ -182,8 +182,9 @@ enum class EMsg : uint16_t
     ArcadeScore,
     PluginRPC,
     AssetBundle,
-    VoiceCaps
-    NpcReputation
+    VoiceCaps,
+    NpcReputation,
+    DynamicEvent // DE-1
 };
 
 struct PacketHeader
@@ -1060,6 +1061,13 @@ struct BossPhasePacket
     uint32_t npcId;
     uint8_t phaseIdx;
     uint8_t _pad[3];
+};
+
+struct DynamicEventPacket
+{
+    uint8_t eventType; // 1=PoliceDispatch,2=GangWar
+    uint8_t _pad[3];
+    uint32_t seed;
 };
 
 struct SectorLODPacket

--- a/cp2077-coop/src/runtime/CrimeSpawner.reds
+++ b/cp2077-coop/src/runtime/CrimeSpawner.reds
@@ -4,6 +4,7 @@ public class CrimeTriggerVolume extends ScriptedTriggerBase {
     protected cb func OnEnter(instigator: ref<GameObject>) -> Bool {
         if triggered { return false; };
         if !Net_IsAuthoritative() { return false; };
+        if !CoopSettings.dynamicEvents { return false; };
         triggered = true;
         let name: String = NameToString(GetEntityName());
         let eventId: Uint32 = CoopNet.Fnv1a32(name);

--- a/cp2077-coop/src/runtime/DynamicEventSync.reds
+++ b/cp2077-coop/src/runtime/DynamicEventSync.reds
@@ -1,0 +1,22 @@
+public enum DynamicEventType {
+    PoliceDispatch = 1,
+    GangWar = 2
+}
+
+public class DynamicEventSync {
+    public static func OnEvent(eventType: Uint8, seed: Uint32) -> Void {
+        LogChannel(n"event", "Dynamic event " + IntToString(Cast<Int32>(eventType)) + " seed=" + IntToString(Cast<Int32>(seed)));
+    }
+
+    public static func SendEvent(eventType: Uint8) -> Void {
+        if !CoopSettings.dynamicEvents { return; };
+        if Net_IsAuthoritative() {
+            let s: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(eventType)) + IntToString(Cast<Int32>(CoopNet.GameClock.GetCurrentTick())));
+            CoopNet.Net_BroadcastDynamicEvent(eventType, s);
+        };
+    }
+}
+
+public static func DynamicEventSync_OnEvent(pkt: ref<DynamicEventPacket>) -> Void {
+    DynamicEventSync.OnEvent(pkt.eventType, pkt.seed);
+}

--- a/cp2077-coop/src/runtime/PoliceDispatch.reds
+++ b/cp2077-coop/src/runtime/PoliceDispatch.reds
@@ -12,6 +12,7 @@ public class PoliceDispatch {
     }
 
     public static func Tick(dtMs: Uint32) -> Void {
+        if !CoopSettings.dynamicEvents { return; };
         waveTimerMs += dtMs;
         let interval: Uint32 = HeatSync.heatLevel >= 3u ? 15000u : 30000u;
         if waveTimerMs >= interval {


### PR DESCRIPTION
### Summary
* Added `DynamicEvent` message type and packet for server broadcasts
* Implemented `Net_BroadcastDynamicEvent` with handlers in `Connection.cpp`
* New `DynamicEventSync.reds` processes events and can send them when host
  settings allow
* `CoopSettings` now includes `dynamicEvents` option stored in `coop.ini`
* Police dispatch and crime spawner check `dynamicEvents` before broadcasting

### Testing Performed
- `python cp2077-coop/tests/test_handle_packet.py`
- `python cp2077-coop/tests/test_quest_sync.py`
- `python cp2077-coop/tests/test_spatial_grid.py`
- `python cp2077-coop/tests/test_interest_bandwidth.py`


------
https://chatgpt.com/codex/tasks/task_e_686f2b0789ec8330a1f21bcb492130a8