### PR TITLE
Add voice indicator overlay with mute controls

### DIFF
--- a/cp2077-coop/src/core/CoopExports.cpp
+++ b/cp2077-coop/src/core/CoopExports.cpp
@@ -112,6 +112,14 @@ static void VoiceStopFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, voi
     CoopVoice::StopCapture();
 }
 
+static void VoiceSetVolumeFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*, void*)
+{
+    float vol = 1.f;
+    RED4ext::GetParameter(aFrame, &vol);
+    aFrame->code++;
+    CoopVoice::SetVolume(vol);
+}
+
 static RED4ext::TTypedClass<CoopNet::HttpResponse> g_httpRespCls("HttpResponse");
 static RED4ext::TTypedClass<CoopNet::HttpAsyncResult> g_httpAsyncCls("HttpAsyncResult");
 
@@ -214,6 +222,11 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes()
     auto vstop = RED4ext::CGlobalFunction::Create("CoopVoice_StopCapture", "CoopVoice_StopCapture", &VoiceStopFn);
     vstop->flags = flags;
     rtti->RegisterFunction(vstop);
+
+    auto vvol = RED4ext::CGlobalFunction::Create("CoopVoice_SetVolume", "CoopVoice_SetVolume", &VoiceSetVolumeFn);
+    vvol->flags = flags;
+    vvol->AddParam("Float", "volume");
+    rtti->RegisterFunction(vvol);
 }
 
 RED4EXT_C_EXPORT bool RED4EXT_CALL Main(RED4ext::PluginHandle aHandle, RED4ext::EMainReason aReason, const RED4ext::Sdk* aSdk)

--- a/cp2077-coop/src/gui/VoiceIndicator.reds
+++ b/cp2077-coop/src/gui/VoiceIndicator.reds
@@ -1,0 +1,115 @@
+public class VoiceIndicator extends inkHUDLayer {
+    private struct IconInfo {
+        public let peer: Uint32;
+        public let widget: ref<inkRectangle>;
+        public var fade: Float;
+    }
+    private static let s_instance: ref<VoiceIndicator>;
+    private let icons: array<IconInfo>;
+    private let muteBtn: ref<inkText>;
+    private let volUp: ref<inkText>;
+    private let volDown: ref<inkText>;
+    private var volume: Float = 1.0;
+    private var muted: Bool;
+
+    public static func Instance() -> ref<VoiceIndicator> {
+        if !IsDefined(s_instance) {
+            s_instance = new VoiceIndicator();
+            GameInstance.GetHUDManager(GetGame()).AddLayer(s_instance);
+        };
+        return s_instance;
+    }
+
+    public static func OnVoice(peerId: Uint32) -> Void {
+        Instance().MarkSpeaking(peerId);
+    }
+
+    private func MarkSpeaking(peerId: Uint32) -> Void {
+        var idx: Int32 = 0;
+        while idx < icons.Size() && icons[idx].peer != peerId { idx += 1; };
+        if idx == icons.Size() {
+            let info: IconInfo;
+            info.peer = peerId;
+            info.widget = new inkRectangle();
+            info.widget.SetSize(32.0,32.0);
+            info.widget.SetTintColor(new HDRColor(1.0,1.0,1.0,1.0));
+            AddChild(info.widget);
+            icons.PushBack(info);
+            idx = icons.Size() - 1;
+        };
+        icons[idx].fade = 1.0;
+        icons[idx].widget.SetOpacity(1.0);
+    }
+
+    protected func OnCreate() -> Void {
+        muteBtn = new inkText();
+        muteBtn.SetText("Mute");
+        muteBtn.SetAnchor(inkEAnchor.TopRight);
+        muteBtn.SetMargin(new inkMargin(0.0,20.0,120.0,0.0));
+        AddChild(muteBtn);
+        muteBtn.RegisterToCallback(n"OnRelease", this, n"OnMuteClick");
+
+        volUp = new inkText();
+        volUp.SetText("+");
+        volUp.SetAnchor(inkEAnchor.TopRight);
+        volUp.SetMargin(new inkMargin(0.0,20.0,80.0,0.0));
+        AddChild(volUp);
+        volUp.RegisterToCallback(n"OnRelease", this, n"OnVolUp");
+
+        volDown = new inkText();
+        volDown.SetText("-");
+        volDown.SetAnchor(inkEAnchor.TopRight);
+        volDown.SetMargin(new inkMargin(0.0,20.0,100.0,0.0));
+        AddChild(volDown);
+        volDown.RegisterToCallback(n"OnRelease", this, n"OnVolDown");
+    }
+
+    protected cb func OnMuteClick(widget: ref<inkWidget>) -> Bool {
+        muted = !muted;
+        if muted {
+            CoopVoice.SetVolume(0.0);
+        } else {
+            CoopVoice.SetVolume(volume);
+        };
+        return true;
+    }
+
+    protected cb func OnVolUp(widget: ref<inkWidget>) -> Bool {
+        volume += 0.1;
+        CoopVoice.SetVolume(volume);
+        return true;
+    }
+
+    protected cb func OnVolDown(widget: ref<inkWidget>) -> Bool {
+        volume -= 0.1;
+        if volume < 0.0 { volume = 0.0; };
+        CoopVoice.SetVolume(volume);
+        return true;
+    }
+
+    public func OnUpdate(dt: Float) -> Void {
+        let playerSys = GameInstance.GetPlayerSystem(GetGame());
+        let players = playerSys.GetPlayers();
+        var i: Int32 = 0;
+        while i < icons.Size() {
+            icons[i].fade -= dt*2.0;
+            if icons[i].fade <= 0.0 {
+                RemoveChild(icons[i].widget);
+                icons.Erase(i);
+                continue;
+            };
+            let av = playerSys.FindObject(icons[i].peer) as AvatarProxy;
+            if IsDefined(av) {
+                let pos = av.pos + new Vector3(0.0,0.0,1.8);
+                let screen = GameInstance.GetViewportManager(GetGame()).WorldToScreen(pos);
+                icons[i].widget.SetMargin(new inkMargin(screen.X-16.0, screen.Y-60.0,0.0,0.0));
+            };
+            icons[i].widget.SetOpacity(icons[i].fade);
+            i += 1;
+        };
+    }
+}
+
+public static func VoiceIndicator_OnVoice(peerId: Uint32) -> Void {
+    VoiceIndicator.OnVoice(peerId);
+}

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -1170,6 +1170,8 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             {
                 if (!voiceMuted)
                     CoopVoice::PushPacket(pkt->seq, pkt->data, pkt->size);
+                if (!voiceMuted)
+                    RED4ext::ExecuteFunction("VoiceIndicator", "OnVoice", nullptr, peerId);
                 voiceRecv++;
             }
         }

--- a/cp2077-coop/src/runtime/VoiceAPI.reds
+++ b/cp2077-coop/src/runtime/VoiceAPI.reds
@@ -2,4 +2,5 @@ public class CoopVoice {
     public static native func StartCapture(device: String, sampleRate: Uint32, bitrate: Uint32) -> Bool
     public static native func EncodeFrame(pcm: script_ref<Int16>, buf: script_ref<Uint8>) -> Int32
     public static native func StopCapture() -> Void
+    public static native func SetVolume(vol: Float) -> Void
 }

--- a/cp2077-coop/src/voice/VoiceDecoder.cpp
+++ b/cp2077-coop/src/voice/VoiceDecoder.cpp
@@ -28,6 +28,7 @@ static ALCcontext* g_ctx = nullptr;
 static ALuint g_source = 0;
 static ALuint g_buffers[4];
 static int g_bufIndex = 0;
+static float g_volume = 1.0f;
 
 void PushPacket(uint16_t seq, const uint8_t* data, uint16_t size)
 {
@@ -86,6 +87,7 @@ static bool EnsureAL()
     alGenSources(1, &g_source);
     alGenBuffers(4, g_buffers);
     g_bufIndex = 0;
+    alSourcef(g_source, AL_GAIN, g_volume);
     return true;
 }
 
@@ -173,5 +175,12 @@ void Reset()
         g_dev = nullptr;
     }
     g_bufIndex = 0;
+}
+
+void SetVolume(float volume)
+{
+    g_volume = std::clamp(volume, 0.0f, 2.0f);
+    if (g_source)
+        alSourcef(g_source, AL_GAIN, g_volume);
 }
 } // namespace CoopVoice

--- a/cp2077-coop/src/voice/VoiceDecoder.hpp
+++ b/cp2077-coop/src/voice/VoiceDecoder.hpp
@@ -7,4 +7,5 @@ void PushPacket(uint16_t seq, const uint8_t* data, uint16_t size);
 int DecodeFrame(int16_t* pcmOut);
 uint16_t ConsumeDropPct();
 void Reset();
+void SetVolume(float volume);
 } // namespace CoopVoice


### PR DESCRIPTION
### Summary
* Added `VoiceIndicator.reds` to track speaking players and show icons above avatars with fade-out.
* Expanded voice API with `SetVolume` and exported new native via `CoopExports`.
* Updated `VoiceDecoder` to handle volume, including OpenAL gain setup.
* Trigger voice indicator from `Connection` when voice packets arrive.

### Testing Performed
- `python3 tools/gen_plugin_docs.py` (no output)


------
https://chatgpt.com/codex/tasks/task_e_686f2b16921483308b7bebcdebb23543