### PR TITLE
Add respawn spectator transition

### DIFF
--- a/cp2077-coop/src/runtime/Respawn.reds
+++ b/cp2077-coop/src/runtime/Respawn.reds
@@ -9,6 +9,11 @@ public class Respawn {
 
     public static func RequestRespawn(peerId: Uint32) -> Void {
         LogChannel(n"DEBUG", "RequestRespawn " + IntToString(peerId));
+        // Send spectate packet so the dead player can watch others during delay.
+        let players = GameInstance.GetPlayerSystem(GetGame()).GetPlayers();
+        var target: Uint32 = 0u;
+        for p in players { if p.peerId != peerId { target = p.peerId; break; }; };
+        if target != 0u { CoopNet.Net_SendSpectateGranted(target); };
         GameInstance.GetDelaySystem(GetGame()).DelayCallback(Respawn, n"PerformRespawn", Cast<Float>(kRespawnDelayMs) / 1000.0, peerId);
     }
 
@@ -40,5 +45,6 @@ public class Respawn {
         board.deaths += 1u;
         board.Update(peerId, board.kills, board.deaths);
         CoopNet.AddStats(peerId, board.kills, board.deaths, 0u, 0u, 0u);
+        SpectatorCam.Exit();
     }
 }

--- a/cp2077-coop/src/runtime/SpectatorCam.reds
+++ b/cp2077-coop/src/runtime/SpectatorCam.reds
@@ -27,6 +27,19 @@ public class SpectatorCam {
         LogChannel(n"DEBUG", "EnterSpectate " + IntToString(peerId));
     }
 
+    // Restores normal HUD and exits spectator mode.
+    public static func Exit() -> Void {
+        let hudMgr = GameInstance.GetHUDManager(GetGame());
+        let list = hudMgr.GetLayers();
+        for layer in list { layer.SetVisible(true); };
+        if IsDefined(hud) {
+            hudMgr.RemoveLayer(hud);
+            hud = null;
+        };
+        GameModeManager.current = GameModeManager.GameMode.DM;
+        LogChannel(n"DEBUG", "ExitSpectate");
+    }
+
     // Very simple free-fly camera controls using WASD.
     public static func UpdateInput(dt: Float) -> Void {
         if GameModeManager.current != GameModeManager.GameMode.Spectate { return; };


### PR DESCRIPTION
### Summary
* Integrated spectator mode with respawn requests so dead players automatically watch a teammate until respawn.
* Added `SpectatorCam.Exit()` to restore HUD and normal mode.
* Respawn now notifies the client with `SpectateGranted` and exits spectate once spawning.

### Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2ff8d1148330b6a7b64915a71670