### PR TITLE
Implement scene trigger sync

### DIFF
--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -150,9 +150,10 @@ static void QuestSync_ApplyQuestStage(uint32_t hash, uint16_t stage)
     RED4ext::ExecuteFunction("QuestSync", "ApplyQuestStageByHash", nullptr, &hash, &stage);
 }
 
-static void QuestSync_ApplySceneTrigger(const char* id, bool start)
+static void QuestSync_ApplySceneTrigger(uint32_t nameHash, bool start)
 {
-    std::cout << "SceneTrigger " << id << " start=" << start << std::endl;
+    RED4ext::TweakDBID id{nameHash, 0};
+    RED4ext::ExecuteFunction("QuestSync", "ApplySceneTrigger", nullptr, &id, &start);
 }
 
 static void DMScoreboard_OnScorePacket(uint32_t peerId, uint16_t k, uint16_t d)
@@ -683,7 +684,11 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         }
         break;
     case EMsg::SceneTrigger:
-        QuestSync_ApplySceneTrigger("0", true); // P4-2: parse payload
+        if (size >= sizeof(SceneTriggerPacket))
+        {
+            const SceneTriggerPacket* pkt = reinterpret_cast<const SceneTriggerPacket*>(payload);
+            QuestSync_ApplySceneTrigger(pkt->nameHash, pkt->start != 0);
+        }
         break;
     case EMsg::NpcSpawn:
         if (size >= sizeof(NpcSpawnPacket))

--- a/cp2077-coop/src/net/Net.cpp
+++ b/cp2077-coop/src/net/Net.cpp
@@ -606,6 +606,12 @@ void Net_BroadcastDialogChoice(uint32_t peerId, uint8_t choiceIdx)
     Net_Broadcast(EMsg::DialogChoice, &pkt, sizeof(pkt));
 }
 
+void Net_BroadcastSceneTrigger(uint32_t phaseId, uint32_t nameHash, bool start)
+{
+    SceneTriggerPacket pkt{phaseId, nameHash, static_cast<uint8_t>(start), {0, 0, 0}};
+    Net_Broadcast(EMsg::SceneTrigger, &pkt, sizeof(pkt));
+}
+
 void Net_SendVoiceCaps(CoopNet::Connection* conn, uint16_t maxBytes)
 {
     if (!conn)

--- a/cp2077-coop/src/net/Net.hpp
+++ b/cp2077-coop/src/net/Net.hpp
@@ -77,6 +77,7 @@ void Net_BroadcastCineStart(uint32_t sceneId, uint32_t startTimeMs, uint32_t pha
 void Net_BroadcastViseme(uint32_t npcId, uint8_t visemeId, uint32_t timeMs);
 void Net_SendDialogChoice(uint8_t choiceIdx);
 void Net_BroadcastDialogChoice(uint32_t peerId, uint8_t choiceIdx);
+void Net_BroadcastSceneTrigger(uint32_t phaseId, uint32_t nameHash, bool start);
 void Net_SendVoiceCaps(CoopNet::Connection* conn, uint16_t maxBytes);
 void Net_SendVoice(const uint8_t* data, uint16_t size, uint16_t seq);
 void Net_BroadcastVoice(uint32_t peerId, const uint8_t* data, uint16_t size, uint16_t seq);

--- a/cp2077-coop/src/runtime/QuestSync.reds
+++ b/cp2077-coop/src/runtime/QuestSync.reds
@@ -66,17 +66,30 @@ public class QuestSync {
 
     // Mirror cutscene and scene triggers between peers.
     public static func OnSceneStart(id: TweakDBID) -> Void {
-        // NetCore.BroadcastSceneTrigger(id, true);
+        let hash: Uint32 = CoopNet.Fnv1a32(TDBID.ToStringDEBUG(id));
+        Net_BroadcastSceneTrigger(localPhase, hash, true);
         LogChannel(n"DEBUG", "Send SceneTrigger start " + TDBID.ToStringDEBUG(id));
     }
 
     public static func OnSceneEnd(id: TweakDBID) -> Void {
-        // NetCore.BroadcastSceneTrigger(id, false);
+        let hash: Uint32 = CoopNet.Fnv1a32(TDBID.ToStringDEBUG(id));
+        Net_BroadcastSceneTrigger(localPhase, hash, false);
         LogChannel(n"DEBUG", "Send SceneTrigger end " + TDBID.ToStringDEBUG(id));
     }
 
     public static func ApplySceneTrigger(id: TweakDBID, isStart: Bool) -> Void {
         LogChannel(n"DEBUG", "Apply SceneTrigger " + TDBID.ToStringDEBUG(id) + " start=" + BoolToString(isStart));
+    }
+
+    public static func OnDialogChoice(peerId: Uint32, idx: Uint8) -> Void {
+        LogChannel(n"DEBUG", "DialogChoice " + IntToString(Cast<Int32>(idx)));
+        if !Net_IsAuthoritative() {
+            Net_SendDialogChoice(idx);
+        } else {
+            if CutsceneSync.ApplyDialogChoice(idx) {
+                Net_BroadcastDialogChoice(peerId, idx);
+            };
+        };
     }
 
     public static func SetFreeze(f: Bool) -> Void {


### PR DESCRIPTION
### Summary
- broadcast SceneTrigger packets on quest cutscene start/stop
- sync dialog choices through QuestSync
- handle SceneTrigger packets on the client

### Testing
- `python tools/gen_plugin_docs.py` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686f2ffbf34c833090cf9065e1e688b4