### PR TITLE
Improve dedicated spawn check & docs

### DIFF
--- a/cp2077-coop/README.md
+++ b/cp2077-coop/README.md
@@ -20,3 +20,9 @@ and various gameplay sync stubs:
 The current phase focuses on stability.
 New modules improve crash reporting, ensure consistent build versions,
 and prepare dedicated server listings via periodic heartbeats.
+
+### Dedicated Server
+Run `coop_dedicated` to host a match. Supported arguments:
+
+* `--help` — print a short usage banner then exit.
+* `--port <number>` — override the listen port (default `7777`).

--- a/cp2077-coop/src/core/GameProcess.cpp
+++ b/cp2077-coop/src/core/GameProcess.cpp
@@ -6,6 +6,7 @@
 #include <spawn.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/wait.h>
 #include <filesystem>
 extern char **environ;
 #endif
@@ -45,7 +46,16 @@ bool GameProcess_Launch(const std::string& exe, const std::string& args)
     int ret = posix_spawnp(&pid, exe.c_str(), &actions, &attr, (char* const*)argv, environ);
     posix_spawn_file_actions_destroy(&actions);
     posix_spawnattr_destroy(&attr);
-    return ret == 0;
+
+    if (ret == 0)
+    {
+        int status = 0;
+        pid_t res = waitpid(pid, &status, WNOHANG);
+        if (res == pid)
+            return false; // exited immediately
+        return true;
+    }
+    return false;
 #endif
 }
 


### PR DESCRIPTION
### Summary
- check for immediate exit when spawning coop_dedicated
- document coop_dedicated args in the README

### Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f3016e0588330b9de2e91ccd2702b