### PR TITLE
Handle voice capture errors

### DIFF
--- a/cp2077-coop/src/gui/ChatOverlay.reds
+++ b/cp2077-coop/src/gui/ChatOverlay.reds
@@ -56,10 +56,13 @@ public class ChatOverlay extends inkHUDLayer {
         let input = GameInstance.GetInputSystem(GetGame());
         if input.IsPressed(CoopSettings.pushToTalk) {
             if !talking {
-                CoopVoice.StartCapture("default", CoopSettings.voiceSampleRate, CoopSettings.voiceBitrate);
-                talking = true;
-                LogChannel(n"DEBUG", "PTT start");
-                MicIcon.Show();
+                if CoopVoice.StartCapture("default", CoopSettings.voiceSampleRate, CoopSettings.voiceBitrate) {
+                    talking = true;
+                    LogChannel(n"DEBUG", "PTT start");
+                    MicIcon.Show();
+                } else {
+                    CoopNotice.Show("Microphone init failed");
+                };
             };
             let pcm: array<Int16>;
             pcm.Resize(Cast<Int32>(CoopSettings.voiceSampleRate / 50u));


### PR DESCRIPTION
### Summary
* show error when starting capture fails
* detailed logging for mic init
* capture can be retried without restart

### Testing
- `clang-format` on touched files
- pre-commit failed: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686f301d96f48330ae893b39821e7344