### PR TITLE
Validate Py_BuildValue

### DIFF
--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -655,8 +655,11 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             const ChatPacket* pkt = reinterpret_cast<const ChatPacket*>(payload);
             ChatOverlay_Push(pkt->msg);
             PyObject* d = Py_BuildValue("{s:I,s:s}", "peerId", peerId, "text", pkt->msg);
-            CoopNet::PluginManager_DispatchEvent("OnChatMsg", d);
-            Py_DECREF(d);
+            if (d)
+            {
+                CoopNet::PluginManager_DispatchEvent("OnChatMsg", d);
+            }
+            Py_XDECREF(d);
         }
         break;
     case EMsg::QuestStageP2P:

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,0 +1,6 @@
+# Python Plugin Best Practices
+
+- Validate objects returned from the Python C API before using them.
+- Release temporary Python objects with `Py_XDECREF` to avoid crashes.
+- Clear errors with `PyErr_Clear()` when a failing call is not fatal.
+- Keep event handlers short to minimise blocking of the game thread.


### PR DESCRIPTION
## Summary
- validate return from `Py_BuildValue` in `Connection.cpp`
- free Python objects with `Py_XDECREF`
- add Python best practices docs

## Testing
- `pre-commit` *(fails: Username for 'https://github.com')*


------
https://chatgpt.com/codex/tasks/task_e_686f34d006348330a40f8928b7d1ec20