### PR TITLE
Implement vehicle snapshot reconciliation

### DIFF
--- a/cp2077-coop/CMakeLists.txt
+++ b/cp2077-coop/CMakeLists.txt
@@ -26,6 +26,7 @@ file(GLOB_RECURSE COOP_SOURCES
     src/core/*.cpp
     src/net/*.cpp
     src/server/*.cpp
+    src/physics/*.cpp
     src/voice/*.cpp
 )
 

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -1995,7 +1995,7 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
         if (size >= sizeof(VehicleSnapshotPacket))
         {
             const VehicleSnapshotPacket* pkt = reinterpret_cast<const VehicleSnapshotPacket*>(payload);
-            RED4ext::ExecuteFunction("VehicleProxy", "UpdateSnapshot", nullptr, &pkt->snap);
+            RED4ext::ExecuteFunction("VehicleProxy", "VehicleProxy_UpdateSnap", nullptr, 1u, &pkt->snap);
         }
         break;
     case EMsg::Version:

--- a/cp2077-coop/src/physics/VehiclePhysics.cpp
+++ b/cp2077-coop/src/physics/VehiclePhysics.cpp
@@ -1,0 +1,19 @@
+#include "CarPhysics.hpp"
+
+namespace CoopNet
+{
+// Run physics at a fixed step regardless of frame delta.
+// `accumMs` carries leftover time between frames.
+void StepVehicle(TransformSnap& state, float& accumMs, float dtMs, bool authoritative)
+{
+    accumMs += dtMs;
+    while (accumMs >= kVehicleStepMs)
+    {
+        if (authoritative)
+            ServerSimulate(state, kVehicleStepMs);
+        else
+            ClientPredict(state, kVehicleStepMs);
+        accumMs -= kVehicleStepMs;
+    }
+}
+} // namespace CoopNet


### PR DESCRIPTION
### Summary
- compile physics sources
- add `VehiclePhysics.cpp` with fixed-step integrator
- reconcile vehicle state when applying snapshots
- process `EMsg::VehicleSnapshot` via `VehicleProxy_UpdateSnap`

### Testing Performed
- `python3 scripts/find_patterns.py` *(fails: ModuleNotFoundError: ida_bytes)*

------
https://chatgpt.com/codex/tasks/task_e_686f34a28bf8833096bcbc2050cfb5bf