### PR TITLE
Implement Admin chat command handler

### DIFF
--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -13,6 +13,7 @@
 #include "../voice/VoiceDecoder.hpp"
 #include "../voice/VoiceEncoder.hpp"
 #include "../plugin/PluginManager.hpp"
+#include "../server/AdminCommandHandler.hpp"
 #include "../third_party/zstd/zstd.h"
 #include <openssl/sha.h>
 #include <Python.h>
@@ -643,6 +644,8 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             if (size >= sizeof(ChatPacket))
             {
                 const ChatPacket* pkt = reinterpret_cast<const ChatPacket*>(payload);
+                if (CoopNet::AdminCommandHandler_Handle(peerId, pkt->msg))
+                    break;
                 if (CoopNet::PluginManager_HandleChat(peerId, pkt->msg, false))
                     break;
                 ChatPacket out{peerId, {0}};

--- a/cp2077-coop/src/server/AdminCommandHandler.cpp
+++ b/cp2077-coop/src/server/AdminCommandHandler.cpp
@@ -1,0 +1,59 @@
+#include "AdminCommandHandler.hpp"
+#include "AdminController.hpp"
+#include "Journal.hpp"
+#include "../core/GameClock.hpp"
+#include <sstream>
+
+namespace CoopNet {
+
+bool AdminCommandHandler_Handle(uint32_t senderId, const std::string& text)
+{
+    if (text.empty() || text[0] != '/')
+        return false;
+    std::stringstream ss(text.substr(1));
+    std::string cmd;
+    ss >> cmd;
+    if (cmd == "kick")
+    {
+        uint32_t id;
+        if (ss >> id)
+        {
+            AdminController_Kick(id);
+            Journal_Log(GameClock::GetCurrentTick(), senderId, "kick", id, 0);
+        }
+        return true;
+    }
+    else if (cmd == "ban")
+    {
+        uint32_t id;
+        if (ss >> id)
+        {
+            AdminController_Ban(id);
+            Journal_Log(GameClock::GetCurrentTick(), senderId, "ban", id, 0);
+        }
+        return true;
+    }
+    else if (cmd == "mute")
+    {
+        uint32_t id = 0;
+        uint32_t mins = 0;
+        if (ss >> id)
+            ss >> mins;
+        AdminController_Mute(id, mins);
+        Journal_Log(GameClock::GetCurrentTick(), senderId, "mute", id, static_cast<int32_t>(mins));
+        return true;
+    }
+    else if (cmd == "unmute")
+    {
+        uint32_t id;
+        if (ss >> id)
+        {
+            AdminController_Unmute(id);
+            Journal_Log(GameClock::GetCurrentTick(), senderId, "unmute", id, 0);
+        }
+        return true;
+    }
+    return false;
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/AdminCommandHandler.hpp
+++ b/cp2077-coop/src/server/AdminCommandHandler.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+#include <cstdint>
+
+namespace CoopNet {
+
+// Returns true if the message was an admin command.
+bool AdminCommandHandler_Handle(uint32_t senderId, const std::string& text);
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/AdminController.cpp
+++ b/cp2077-coop/src/server/AdminController.cpp
@@ -196,4 +196,24 @@ bool AdminController_IsBanned(uint32_t peerId)
     return g_banList.count(peerId) != 0;
 }
 
+void AdminController_Kick(uint32_t peerId)
+{
+    DoKick(peerId);
+}
+
+void AdminController_Ban(uint32_t peerId)
+{
+    DoBan(peerId);
+}
+
+void AdminController_Mute(uint32_t peerId, uint32_t mins)
+{
+    DoMute(peerId, mins);
+}
+
+void AdminController_Unmute(uint32_t peerId)
+{
+    DoUnmute(peerId);
+}
+
 } // namespace CoopNet

--- a/cp2077-coop/src/server/AdminController.hpp
+++ b/cp2077-coop/src/server/AdminController.hpp
@@ -10,5 +10,9 @@ void AdminController_Start();
 void AdminController_Stop();
 void AdminController_PollCommands();
 bool AdminController_IsBanned(uint32_t peerId);
+void AdminController_Kick(uint32_t peerId);
+void AdminController_Ban(uint32_t peerId);
+void AdminController_Mute(uint32_t peerId, uint32_t mins);
+void AdminController_Unmute(uint32_t peerId);
 
 } // namespace CoopNet


### PR DESCRIPTION
### Summary
- allow admins to send `/kick`, `/ban`, `/mute` and `/unmute` via chat
- hook chat parsing into `Connection::HandlePacket`
- expose new admin helper functions

### Testing Performed
- `cmake ..` ✅
- `make` ❌ (fails: missing Windows headers)
- pre-commit failed due to missing dependencies


------
https://chatgpt.com/codex/tasks/task_e_686f34afd0088330b74b3e37ffa55069