### PR TITLE
Add player count API and difficulty setting

### DIFF
--- a/cp2077-coop/src/core/CoopExports.cpp
+++ b/cp2077-coop/src/core/CoopExports.cpp
@@ -82,6 +82,13 @@ static void NetPollFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, void*
     Net_Poll(maxMs);
 }
 
+static void SessionActiveCountFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, uint32_t* aOut, void*)
+{
+    aFrame->code++;
+    if (aOut)
+        *aOut = CoopNet::SessionState_GetActivePlayerCount();
+}
+
 static void VoiceStartFn(RED4ext::IScriptable*, RED4ext::CStackFrame* aFrame, bool* aOut, void*)
 {
     RED4ext::CString dev;
@@ -203,6 +210,11 @@ RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes()
     poll->flags = flags;
     poll->AddParam("Uint32", "maxMs");
     rtti->RegisterFunction(poll);
+
+    auto ap = RED4ext::CGlobalFunction::Create("SessionState_GetActivePlayerCount", "SessionState_GetActivePlayerCount", &SessionActiveCountFn);
+    ap->flags = flags;
+    ap->SetReturnType("Uint32");
+    rtti->RegisterFunction(ap);
 
     auto vs = RED4ext::CGlobalFunction::Create("CoopVoice_StartCapture", "CoopVoice_StartCapture", &VoiceStartFn);
     vs->flags = flags;

--- a/cp2077-coop/src/core/SessionState.cpp
+++ b/cp2077-coop/src/core/SessionState.cpp
@@ -137,6 +137,11 @@ uint32_t SessionState_GetId()
     return g_sessionId;
 }
 
+uint32_t SessionState_GetActivePlayerCount()
+{
+    return static_cast<uint32_t>(g_party.size());
+}
+
 void SessionState_SetPerk(uint32_t peerId, uint32_t perkId, uint8_t rank)
 {
     for (auto& p : g_party)

--- a/cp2077-coop/src/core/SessionState.hpp
+++ b/cp2077-coop/src/core/SessionState.hpp
@@ -47,6 +47,9 @@ const WorldStateSnap& SessionState_GetWorld();
 const std::vector<EventState>& SessionState_GetEvents();
 const std::unordered_map<uint32_t, int16_t>& SessionState_GetReputation();
 
+// Returns number of active party members
+uint32_t SessionState_GetActivePlayerCount();
+
 void SessionState_UpdateWeather(uint16_t sunDeg, uint8_t weatherId, uint16_t seed);
 void SessionState_RecordEvent(uint32_t eventId, uint8_t phase, bool active, uint32_t seed);
 void SessionState_SetReputation(uint32_t npcId, int16_t value);

--- a/cp2077-coop/src/gui/CoopSettings.reds
+++ b/cp2077-coop/src/gui/CoopSettings.reds
@@ -9,6 +9,7 @@ public var voiceBitrate: Uint32 = 24000u;
 public var friendlyFire: Bool = false;
 public var sharedLoot: Bool = true;
 public var difficultyScaling: Bool = false;
+public var difficultyLevel: Uint8 = 1u;
 public var dynamicEvents: Bool = true;
 public let kDefaultSettingsPath: String = "coop.ini";
 private native func SaveSettings(json: String) -> Void
@@ -27,6 +28,7 @@ public func Save(path: String) -> Void {
                 ",\"sharedLoot\":" + BoolToString(sharedLoot) +
                 ",\"difficultyScaling\":" + BoolToString(difficultyScaling) +
                 ",\"dynamicEvents\":" + BoolToString(dynamicEvents) +
+                ",\"difficulty\":" + IntToString(Cast<Int32>(difficultyLevel)) +
                 ",\"minTickRate\":" + IntToString(Cast<Int32>(minTickRate)) +
                 ",\"maxTickRate\":" + IntToString(Cast<Int32>(maxTickRate)) + "}";
     SaveSettings(json);

--- a/cp2077-coop/src/runtime/CrimeSpawner.reds
+++ b/cp2077-coop/src/runtime/CrimeSpawner.reds
@@ -12,9 +12,12 @@ public class CrimeTriggerVolume extends ScriptedTriggerBase {
         var pkt: CoopNet.CrimeEventSpawnPacket;
         pkt.eventId = eventId;
         pkt.seed = seed;
-        pkt.count = 3u;
+        let players: Uint32 = SessionState.GetActivePlayerCount();
+        if players == 0u { players = 1u; };
+        if players > 4u { players = 4u; };
+        pkt.count = Cast<Uint8>(players);
         let base: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(GameInstance.GetSimTime(GetGame()))));
-        for i in range(0, 3) {
+        for i in range(0, Cast<Int32>(players)) {
             pkt.npcIds[i] = base + Cast<Uint32>(i);
         };
         CoopNet.Net_BroadcastCrimeEvent(pkt);

--- a/cp2077-coop/src/runtime/DynamicEventSync.reds
+++ b/cp2077-coop/src/runtime/DynamicEventSync.reds
@@ -5,13 +5,15 @@ public enum DynamicEventType {
 
 public class DynamicEventSync {
     public static func OnEvent(eventType: Uint8, seed: Uint32) -> Void {
-        LogChannel(n"event", "Dynamic event " + IntToString(Cast<Int32>(eventType)) + " seed=" + IntToString(Cast<Int32>(seed)));
+        let players: Uint32 = SessionState.GetActivePlayerCount();
+        LogChannel(n"event", "Dynamic event " + IntToString(Cast<Int32>(eventType)) + " seed=" + IntToString(Cast<Int32>(seed)) + " players=" + IntToString(Cast<Int32>(players)));
     }
 
     public static func SendEvent(eventType: Uint8) -> Void {
         if !CoopSettings.dynamicEvents { return; };
         if Net_IsAuthoritative() {
-            let s: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(eventType)) + IntToString(Cast<Int32>(CoopNet.GameClock.GetCurrentTick())));
+            let players: Uint32 = SessionState.GetActivePlayerCount();
+            let s: Uint32 = CoopNet.Fnv1a32(IntToString(Cast<Int32>(eventType)) + IntToString(Cast<Int32>(CoopNet.GameClock.GetCurrentTick())) + IntToString(Cast<Int32>(players)));
             CoopNet.Net_BroadcastDynamicEvent(eventType, s);
         };
     }

--- a/cp2077-coop/src/runtime/SessionState.reds
+++ b/cp2077-coop/src/runtime/SessionState.reds
@@ -1,0 +1,3 @@
+public class SessionState {
+    public static native func GetActivePlayerCount() -> Uint32
+}


### PR DESCRIPTION
## Summary
- expose active player count from `SessionState`
- log player count in `DynamicEventSync` and use it for crime spawns
- store difficulty level in `CoopSettings`

## Testing
- `python3 scripts/find_patterns.py` *(fails: ModuleNotFoundError: ida_bytes)*
- `python3 tools/gen_plugin_docs.py`
- `python3 scripts/patterns.py`

------
https://chatgpt.com/codex/tasks/task_e_686f3503a3688330ad1e754ceb218066