### PR TITLE
Implement bundle cache limit

### DIFF
--- a/cp2077-coop/src/gui/CoopSettings.reds
+++ b/cp2077-coop/src/gui/CoopSettings.reds
@@ -10,6 +10,8 @@ public var friendlyFire: Bool = false;
 public var sharedLoot: Bool = true;
 public var difficultyScaling: Bool = false;
 public var dynamicEvents: Bool = true;
+public var bundleCacheLimitMb: Uint32 = 128u;
+public static func GetBundleCacheLimitMb() -> Uint32 { return bundleCacheLimitMb; }
 public let kDefaultSettingsPath: String = "coop.ini";
 private native func SaveSettings(json: String) -> Void
 

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -27,6 +27,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <iostream>
+#include <algorithm>
+#include <vector>
 
 // Temporary proxies for script methods.
 static void AvatarProxy_SpawnRemote(uint32_t peerId, bool isLocal, const CoopNet::TransformSnap& snap)
@@ -80,6 +82,7 @@ namespace
 
     std::unordered_map<uint16_t, BundleBuf> g_bundle;
     std::unordered_map<uint16_t, std::string> g_bundleSha;
+    constexpr uint64_t kBundleLimit = 128ull * 1024ull * 1024ull; // 128 MB
 
     size_t GetBundleMemory()
     {
@@ -98,6 +101,45 @@ namespace
         g_bundleSha.clear();
         std::cerr << "[MemGuard] bundle cache freed " << before
                   << " bytes, RSS=" << GetProcessRSS() << std::endl;
+    }
+
+    uint64_t DirSize(const std::filesystem::path& p)
+    {
+        uint64_t total = 0;
+        for (auto& f : std::filesystem::recursive_directory_iterator(p))
+            if (f.is_regular_file())
+                total += f.file_size();
+        return total;
+    }
+
+    void EnforceBundleLimit()
+    {
+        namespace fs = std::filesystem;
+        fs::path base = fs::path("runtime_cache") / "plugins";
+        if (!fs::exists(base))
+            return;
+        struct Entry { fs::path path; uint64_t size; fs::file_time_type mtime; };
+        std::vector<Entry> ent;
+        uint64_t total = 0;
+        for (auto& dir : fs::directory_iterator(base))
+        {
+            if (!dir.is_directory())
+                continue;
+            uint64_t sz = DirSize(dir.path());
+            ent.push_back({dir.path(), sz, fs::last_write_time(dir.path())});
+            total += sz;
+        }
+        std::sort(ent.begin(), ent.end(), [](const Entry& a, const Entry& b)
+                  { return a.mtime < b.mtime; });
+        for (const auto& e : ent)
+        {
+            if (total <= kBundleLimit)
+                break;
+            fs::remove_all(e.path);
+            total -= e.size;
+            std::cerr << "[AssetCache] purged bundle " << e.path.filename().string()
+                      << std::endl;
+        }
     }
 
     bool HandleBundleComplete(uint16_t pluginId, const std::vector<uint8_t>& comp)
@@ -144,6 +186,8 @@ namespace
             f.write(reinterpret_cast<const char*>(p), len);
             p += len;
         }
+        std::filesystem::last_write_time(base, std::filesystem::file_time_type::clock::now());
+        EnforceBundleLimit();
         RED4ext::CString path(base.string().c_str());
         bool ro = true; // sandbox client scripts
         RED4ext::ExecuteFunction("ModSystem", "Mount", nullptr, &path, &ro);


### PR DESCRIPTION
### Summary
- add LRU eviction to asset bundle handler
- expose `bundleCacheLimitMb` in `CoopSettings`

### Testing Performed
- `pre-commit` *(fails: requires GitHub access)*


------
https://chatgpt.com/codex/tasks/task_e_686f373554d083309fe51579ab8e00bd