### PR TITLE
Add runtime debug logging toggle

### DIFF
--- a/cp2077-coop/src/gui/CoopSettings.reds
+++ b/cp2077-coop/src/gui/CoopSettings.reds
@@ -10,8 +10,10 @@ public var friendlyFire: Bool = false;
 public var sharedLoot: Bool = true;
 public var difficultyScaling: Bool = false;
 public var dynamicEvents: Bool = true;
+public var verboseLogging: Bool = false;
 public let kDefaultSettingsPath: String = "coop.ini";
 private native func SaveSettings(json: String) -> Void
+private static native func Net_SetVerboseLog(enable: Bool) -> Void
 
 public func Show() -> Void {
     // UI-4: open settings ink panel
@@ -20,6 +22,7 @@ public func Show() -> Void {
 
 public func Apply() -> Void {
     GameModeManager.SetFriendlyFire(friendlyFire);
+    Net_SetVerboseLog(verboseLogging);
 }
 
 public func Save(path: String) -> Void {
@@ -27,6 +30,7 @@ public func Save(path: String) -> Void {
                 ",\"sharedLoot\":" + BoolToString(sharedLoot) +
                 ",\"difficultyScaling\":" + BoolToString(difficultyScaling) +
                 ",\"dynamicEvents\":" + BoolToString(dynamicEvents) +
+                ",\"verboseLogging\":" + BoolToString(verboseLogging) +
                 ",\"minTickRate\":" + IntToString(Cast<Int32>(minTickRate)) +
                 ",\"maxTickRate\":" + IntToString(Cast<Int32>(maxTickRate)) + "}";
     SaveSettings(json);

--- a/cp2077-coop/src/net/Net.cpp
+++ b/cp2077-coop/src/net/Net.cpp
@@ -6,9 +6,9 @@
 #include "../server/Journal.hpp"
 #include "../server/PoliceDispatch.hpp"
 #include "../server/QuestWatchdog.hpp"
+#include "../voice/VoiceEncoder.hpp"
 #include "Connection.hpp"
 #include "NatClient.hpp"
-#include "../voice/VoiceEncoder.hpp"
 #include "NetConfig.hpp"
 #include "Packets.hpp"
 #include <algorithm>
@@ -177,6 +177,16 @@ bool Net_IsAuthoritative()
 bool Net_IsConnected()
 {
     return !g_Peers.empty();
+}
+
+void Net_SetVerboseLogging(bool enable)
+{
+    CoopNet::SetVerboseLogging(enable);
+}
+
+bool Net_IsVerboseLogging()
+{
+    return CoopNet::IsVerboseLogging();
 }
 
 std::vector<Connection*> Net_GetConnections()
@@ -671,7 +681,7 @@ void Net_SendGlobalEvent(Connection* conn, uint32_t eventId, uint8_t phase, bool
 {
     if (!conn)
         return;
-    GlobalEventPacket pkt{eventId, seed, phase, static_cast<uint8_t>(start), {0,0}};
+    GlobalEventPacket pkt{eventId, seed, phase, static_cast<uint8_t>(start), {0, 0}};
     Net_Send(conn, EMsg::GlobalEvent, &pkt, sizeof(pkt));
 }
 
@@ -679,13 +689,13 @@ void Net_SendNpcReputation(Connection* conn, uint32_t npcId, int16_t value)
 {
     if (!conn)
         return;
-    NpcReputationPacket pkt{npcId, value, {0,0}};
+    NpcReputationPacket pkt{npcId, value, {0, 0}};
     Net_Send(conn, EMsg::NpcReputation, &pkt, sizeof(pkt));
 }
 
 void Net_BroadcastNpcReputation(uint32_t npcId, int16_t value)
 {
-    NpcReputationPacket pkt{npcId, value, {0,0}};
+    NpcReputationPacket pkt{npcId, value, {0, 0}};
     Net_Broadcast(EMsg::NpcReputation, &pkt, sizeof(pkt));
 }
 
@@ -697,7 +707,7 @@ void Net_BroadcastGlobalEvent(uint32_t eventId, uint8_t phase, bool start, uint3
 
 void Net_BroadcastDynamicEvent(uint8_t eventType, uint32_t seed)
 {
-    DynamicEventPacket pkt{eventType, {0,0,0}, seed};
+    DynamicEventPacket pkt{eventType, {0, 0, 0}, seed};
     Net_Broadcast(EMsg::DynamicEvent, &pkt, sizeof(pkt));
 }
 
@@ -1381,8 +1391,7 @@ void Net_BroadcastArcadeHighScore(uint32_t cabId, uint32_t peerId, uint32_t scor
     Net_Broadcast(EMsg::ArcadeHighScore, &pkt, sizeof(pkt));
 }
 
-void Net_SendPluginRPC(Connection* conn, uint16_t pluginId, uint32_t fnHash,
-                       const char* json, uint16_t len)
+void Net_SendPluginRPC(Connection* conn, uint16_t pluginId, uint32_t fnHash, const char* json, uint16_t len)
 {
     std::vector<uint8_t> buf(sizeof(PluginRPCPacket) - 1 + len);
     auto* pkt = reinterpret_cast<PluginRPCPacket*>(buf.data());
@@ -1393,8 +1402,7 @@ void Net_SendPluginRPC(Connection* conn, uint16_t pluginId, uint32_t fnHash,
     Net_Send(conn, EMsg::PluginRPC, buf.data(), static_cast<uint16_t>(buf.size()));
 }
 
-void Net_BroadcastPluginRPC(uint16_t pluginId, uint32_t fnHash, const char* json,
-                            uint16_t len)
+void Net_BroadcastPluginRPC(uint16_t pluginId, uint32_t fnHash, const char* json, uint16_t len)
 {
     std::vector<uint8_t> buf(sizeof(PluginRPCPacket) - 1 + len);
     auto* pkt = reinterpret_cast<PluginRPCPacket*>(buf.data());

--- a/cp2077-coop/src/net/Net.hpp
+++ b/cp2077-coop/src/net/Net.hpp
@@ -25,6 +25,8 @@ void Net_Shutdown();
 void Net_Poll(uint32_t maxMs);
 bool Net_IsAuthoritative();
 bool Net_IsConnected();
+void Net_SetVerboseLogging(bool enable);
+bool Net_IsVerboseLogging();
 std::vector<CoopNet::Connection*> Net_GetConnections();
 void Net_Send(CoopNet::Connection* conn, CoopNet::EMsg type, const void* data, uint16_t size);
 void Net_Broadcast(CoopNet::EMsg type, const void* data, uint16_t size);
@@ -207,8 +209,6 @@ void Net_BroadcastArcadeStart(uint32_t cabId, uint32_t peerId, uint32_t seed);
 void Net_SendArcadeInput(uint32_t frame, uint8_t buttonMask);
 void Net_BroadcastArcadeScore(uint32_t peerId, uint32_t score);
 void Net_BroadcastArcadeHighScore(uint32_t cabId, uint32_t peerId, uint32_t score);
-void Net_SendPluginRPC(CoopNet::Connection* conn, uint16_t pluginId, uint32_t fnHash,
-                       const char* json, uint16_t len);
-void Net_BroadcastPluginRPC(uint16_t pluginId, uint32_t fnHash, const char* json,
-                            uint16_t len);
+void Net_SendPluginRPC(CoopNet::Connection* conn, uint16_t pluginId, uint32_t fnHash, const char* json, uint16_t len);
+void Net_BroadcastPluginRPC(uint16_t pluginId, uint32_t fnHash, const char* json, uint16_t len);
 void Net_BroadcastAssetBundle(uint16_t pluginId, const std::vector<uint8_t>& data);


### PR DESCRIPTION
### Summary
* Wrapped verbose `std::cout` calls in `Connection.cpp` with `DEBUG_LOG` guarded `DEBUG_PRINT` macro.
* Added runtime toggle via `CoopSettings.verboseLogging` with native bridge functions.
* Registered `Net_SetVerboseLog` and `Net_IsVerboseLog` for scripts.

### Testing Performed
- `clang-format` on modified C++ files.
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f34d657c48330889359a018fdbf3f