### PR TITLE
Implement world state persistence and admin commands

### DIFF
--- a/cp2077-coop/src/server/WorldStateIO.cpp
+++ b/cp2077-coop/src/server/WorldStateIO.cpp
@@ -1,0 +1,35 @@
+#include "WorldStateIO.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace CoopNet {
+
+static const char* kWorldStatePath = "server/world_state.json";
+
+bool LoadWorldState(WorldStatePacket& out)
+{
+    std::ifstream in(kWorldStatePath);
+    if (!in.is_open())
+        return false;
+    std::string json((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    if (std::sscanf(json.c_str(), "{\"sun\":%hu,\"id\":%hhu,\"seed\":%hu}", &out.sunAngleDeg, &out.weatherId, &out.particleSeed) == 3)
+        return true;
+    return false;
+}
+
+void SaveWorldState(const WorldStatePacket& state)
+{
+    try {
+        std::filesystem::create_directories("server");
+        std::ofstream outFile(kWorldStatePath, std::ios::trunc);
+        if (!outFile.is_open())
+            return;
+        outFile << "{\"sun\":" << state.sunAngleDeg << ",\"id\":" << static_cast<int>(state.weatherId)
+                << ",\"seed\":" << state.particleSeed << "}\n";
+    } catch (const std::exception& e) {
+        std::cerr << "SaveWorldState error: " << e.what() << std::endl;
+    }
+}
+
+} // namespace CoopNet

--- a/cp2077-coop/src/server/WorldStateIO.hpp
+++ b/cp2077-coop/src/server/WorldStateIO.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include "../net/Packets.hpp"
+
+namespace CoopNet {
+
+bool LoadWorldState(WorldStatePacket& out);
+void SaveWorldState(const WorldStatePacket& state);
+
+} // namespace CoopNet


### PR DESCRIPTION
### Ticket
Manual patch · Save world state

### Summary
* Added `WorldStateIO` helper with load/save functions for `WorldStatePacket`.
* Dedicated server now loads saved world state on startup and writes it on shutdown.
* Admin commands `/snapshot` and `/reset` persist or restore world state.

### Files Touched
- `cp2077-coop/src/server/WorldStateIO.hpp` **(new)**
- `cp2077-coop/src/server/WorldStateIO.cpp` **(new)**
- `cp2077-coop/src/server/DedicatedMain.cpp` (+14)
- `cp2077-coop/src/server/AdminCommandHandler.cpp` (+30)
- `cp2077-coop/src/server/AdminController.cpp` (+32)

### Logic Walk-Through
1. `LoadWorldState()` parses `server/world_state.json`.
2. `SaveWorldState()` writes out the structure.
3. Startup applies loaded state via `SessionState_UpdateWeather`.
4. Shutdown writes the last broadcast state.
5. `/snapshot` saves the session and world state while `/reset` reloads and broadcasts it.

### Unfinished / TODO
- Timer sync after `/reset` to align day/night cycle.

### Testing Performed
- `pytest -q` → all tests pass.

### Links / Context
Continues persistence work for dedicated server.

------
https://chatgpt.com/codex/tasks/task_e_686f3ad9d66c8330877c1c264875d0b8