### PR TITLE
Implement PartyManager RPCs

### DIFF
--- a/cp2077-coop/src/core/SessionState.cpp
+++ b/cp2077-coop/src/core/SessionState.cpp
@@ -1,6 +1,7 @@
 #include "SessionState.hpp"
 #include "SaveFork.hpp"
 #include "SaveMigration.hpp"
+#include "../net/Net.hpp"
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -47,6 +48,8 @@ uint32_t SessionState_SetParty(const std::vector<uint32_t>& peerIds)
     g_sessionId = hash;
     if (g_sessionId != prev)
         LoadSessionState(g_sessionId);
+    if (!sorted.empty())
+        Net_BroadcastPartyInfo(sorted.data(), static_cast<uint8_t>(sorted.size()));
     return g_sessionId;
 }
 

--- a/cp2077-coop/src/gui/ServerBrowser.reds
+++ b/cp2077-coop/src/gui/ServerBrowser.reds
@@ -6,6 +6,7 @@ public class ServerBrowser extends inkHUDLayer {
     private static let joinBtn: wref<inkButton>;
     private static let hostBtn: wref<inkButton>;
     private static let loadingSpinner: wref<inkText>;
+    private static let partyText: wref<inkText>;
     private static var masterToken: Uint32;
     private static let pending: ref<inkHashMap> = new inkHashMap();
     private static var pendingCount: Uint32;
@@ -54,6 +55,9 @@ public class ServerBrowser extends inkHUDLayer {
         loadingSpinner.SetText("Loading...");
         loadingSpinner.SetVisible(false);
         root.AddChild(loadingSpinner);
+        partyText = new inkText();
+        partyText.SetText("Party: " + IntToString(Cast<Int32>(SessionState_GetActivePlayerCount())));
+        root.AddChild(partyText);
         RefreshLive();
     }
 
@@ -255,6 +259,10 @@ public class ServerBrowser extends inkHUDLayer {
             } else if input.GetMouseWheel() != 0 {
                 scrollCtrl.ScrollBy(input.GetMouseWheel());
             }
+        }
+
+        if IsDefined(partyText) {
+            partyText.SetText("Party: " + IntToString(Cast<Int32>(SessionState_GetActivePlayerCount())));
         }
 
         let res = HttpRequest.PollAsync();

--- a/cp2077-coop/src/net/Connection.cpp
+++ b/cp2077-coop/src/net/Connection.cpp
@@ -1635,6 +1635,34 @@ void Connection::HandlePacket(const PacketHeader& hdr, const void* payload, uint
             CoopNet::QuestWatchdog_HandleEndingVote(peerId, pkt->yes != 0);
         }
         break;
+    case EMsg::PartyInfo:
+        if (size >= sizeof(PartyInfoPacket))
+        {
+            const PartyInfoPacket* pkt = reinterpret_cast<const PartyInfoPacket*>(payload);
+            PartyManager_OnPartyInfo(pkt->peerIds, pkt->count);
+        }
+        break;
+    case EMsg::PartyInvite:
+        if (size >= sizeof(PartyInvitePacket))
+        {
+            const PartyInvitePacket* pkt = reinterpret_cast<const PartyInvitePacket*>(payload);
+            PartyManager_OnInvite(pkt->fromId, pkt->toId);
+        }
+        break;
+    case EMsg::PartyLeave:
+        if (size >= sizeof(PartyLeavePacket))
+        {
+            const PartyLeavePacket* pkt = reinterpret_cast<const PartyLeavePacket*>(payload);
+            PartyManager_OnLeave(pkt->peerId);
+        }
+        break;
+    case EMsg::PartyKick:
+        if (size >= sizeof(PartyKickPacket))
+        {
+            const PartyKickPacket* pkt = reinterpret_cast<const PartyKickPacket*>(payload);
+            PartyManager_OnKick(pkt->peerId);
+        }
+        break;
     case EMsg::PhaseBundle:
         if (size >= sizeof(PhaseBundlePacket) && !Net_IsAuthoritative())
         {

--- a/cp2077-coop/src/net/Net.cpp
+++ b/cp2077-coop/src/net/Net.cpp
@@ -1063,6 +1063,63 @@ void Net_SendEndingVoteCast(bool yes)
     }
 }
 
+void Net_BroadcastPartyInfo(const uint32_t* ids, uint8_t count)
+{
+    PartyInfoPacket pkt{};
+    pkt.count = count > 8 ? 8 : count;
+    for (uint8_t i = 0; i < pkt.count; ++i)
+        pkt.peerIds[i] = ids[i];
+    Net_Broadcast(EMsg::PartyInfo, &pkt, sizeof(pkt));
+}
+
+void Net_SendPartyInvite(uint32_t targetPeerId)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        PartyInvitePacket pkt{Net_GetPeerId(), targetPeerId};
+        Net_Send(conns[0], EMsg::PartyInvite, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendPartyLeave()
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        PartyLeavePacket pkt{Net_GetPeerId()};
+        Net_Send(conns[0], EMsg::PartyLeave, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_SendPartyKick(uint32_t peerId)
+{
+    auto conns = Net_GetConnections();
+    if (!conns.empty())
+    {
+        PartyKickPacket pkt{peerId};
+        Net_Send(conns[0], EMsg::PartyKick, &pkt, sizeof(pkt));
+    }
+}
+
+void Net_BroadcastPartyInvite(uint32_t fromId, uint32_t toId)
+{
+    PartyInvitePacket pkt{fromId, toId};
+    Net_Broadcast(EMsg::PartyInvite, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastPartyLeave(uint32_t peerId)
+{
+    PartyLeavePacket pkt{peerId};
+    Net_Broadcast(EMsg::PartyLeave, &pkt, sizeof(pkt));
+}
+
+void Net_BroadcastPartyKick(uint32_t peerId)
+{
+    PartyKickPacket pkt{peerId};
+    Net_Broadcast(EMsg::PartyKick, &pkt, sizeof(pkt));
+}
+
 void Net_SendDealerBuy(uint32_t vehicleTpl, uint32_t price)
 {
     auto conns = Net_GetConnections();

--- a/cp2077-coop/src/net/Net.hpp
+++ b/cp2077-coop/src/net/Net.hpp
@@ -162,6 +162,13 @@ void Net_SendTradeAccept(bool accept);                                          
 void Net_BroadcastTradeFinalize(bool success);                                             // TRD-1
 void Net_BroadcastEndingVoteStart(uint32_t questHash);                                     // EG-1
 void Net_SendEndingVoteCast(bool yes);                                                     // EG-1
+void Net_BroadcastPartyInfo(const uint32_t* ids, uint8_t count);
+void Net_SendPartyInvite(uint32_t targetPeerId);
+void Net_SendPartyLeave();
+void Net_SendPartyKick(uint32_t peerId);
+void Net_BroadcastPartyInvite(uint32_t fromId, uint32_t toId);
+void Net_BroadcastPartyLeave(uint32_t peerId);
+void Net_BroadcastPartyKick(uint32_t peerId);
 void Net_BroadcastVehicleSnap(const VehicleSnap& snap);                                    // VT-1
 void Net_BroadcastTurretAim(uint32_t vehId, float yaw, float pitch);                       // VT-2
 void Net_BroadcastAirVehSpawn(uint32_t vehId, const RED4ext::Vector3* pts, uint8_t count); // VT-3

--- a/cp2077-coop/src/net/Packets.hpp
+++ b/cp2077-coop/src/net/Packets.hpp
@@ -142,6 +142,10 @@ enum class EMsg : uint16_t
     TradeFinalize,
     EndingVoteStart, // EG-1
     EndingVoteCast,
+    PartyInfo,
+    PartyInvite,
+    PartyLeave,
+    PartyKick,
     VehicleSnapshot, // VT-1
     TurretAim,       // VT-2
     AirVehSpawn,     // VT-3
@@ -1046,6 +1050,29 @@ struct EndingVoteCastPacket
     uint32_t peerId;
     uint8_t yes;
     uint8_t _pad[3];
+};
+
+struct PartyInfoPacket
+{
+    uint8_t count;
+    uint8_t _pad[3];
+    uint32_t peerIds[8];
+};
+
+struct PartyInvitePacket
+{
+    uint32_t fromId;
+    uint32_t toId;
+};
+
+struct PartyLeavePacket
+{
+    uint32_t peerId;
+};
+
+struct PartyKickPacket
+{
+    uint32_t peerId;
 };
 
 struct VehicleSnapshotPacket

--- a/cp2077-coop/src/runtime/PartyManager.reds
+++ b/cp2077-coop/src/runtime/PartyManager.reds
@@ -1,0 +1,55 @@
+public class PartyManager {
+    public static let members: array<Uint32>;
+
+    public static func Invite(peer: Uint32) -> Void {
+        CoopNet.Net_SendPartyInvite(peer);
+    }
+
+    public static func Leave() -> Void {
+        CoopNet.Net_SendPartyLeave();
+    }
+
+    public static func Kick(peer: Uint32) -> Void {
+        CoopNet.Net_SendPartyKick(peer);
+    }
+
+    public static func OnPartyInfo(ids: script_ref<array<Uint32>>, count: Uint8) -> Void {
+        members.Clear();
+        var i: Int32 = 0;
+        while i < count {
+            members.PushBack(ids[i]);
+            i += 1;
+        };
+    }
+
+    public static func OnInvite(from: Uint32, to: Uint32) -> Void {
+        if to == Net_GetLocalPeerId() {
+            CoopNotice.Show("Invited by " + IntToString(Cast<Int32>(from)));
+        };
+    }
+
+    public static func OnLeave(peer: Uint32) -> Void {
+        CoopNotice.Show("Peer " + IntToString(Cast<Int32>(peer)) + " left party");
+    }
+
+    public static func OnKick(peer: Uint32) -> Void {
+        if peer == Net_GetLocalPeerId() {
+            CoopNotice.Show("Kicked from party");
+        } else {
+            CoopNotice.Show("Kick " + IntToString(Cast<Int32>(peer)));
+        };
+    }
+}
+
+public static func PartyManager_OnPartyInfo(ids: script_ref<array<Uint32>>, count: Uint8) -> Void {
+    PartyManager.OnPartyInfo(ids, count);
+}
+public static func PartyManager_OnInvite(f: Uint32, t: Uint32) -> Void {
+    PartyManager.OnInvite(f, t);
+}
+public static func PartyManager_OnLeave(p: Uint32) -> Void {
+    PartyManager.OnLeave(p);
+}
+public static func PartyManager_OnKick(p: Uint32) -> Void {
+    PartyManager.OnKick(p);
+}


### PR DESCRIPTION
### Summary
* added party-related packets and broadcast helpers
* PartyManager.reds handles invites/leaves/kicks
* SessionState now broadcasts PartyInfo
* ServerBrowser shows current party size

### Testing
- `pre-commit` *(fails: prompts for github credentials)*

------
https://chatgpt.com/codex/tasks/task_e_686f3abd8ed883309f9e9e6863e44395